### PR TITLE
Enable passing `children` prop via `enqueueSnackbar`

### DIFF
--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -72,26 +72,28 @@ class SnackbarItem extends Component {
                 onClose={this.handleClose(key)}
                 onExited={() => onExited(key)}
             >
-                <SnackbarContent
-                    className={classNames(
-                        classes.base,
-                        classes[`variant${capitalise(variant)}`],
-                        className,
-                    )}
-                    {...contentProps}
-                    aria-describedby="client-snackbar"
-                    message={(
-                        <span id="client-snackbar" className={classes.message}>
-                            {!hideIconVariant ? <Icon className={classes.icon} /> : null}
-                            {snack.message}
-                        </span>
-                    )}
-                    action={contentProps.action && (
-                        <span onClick={onClickHandler}>
-                            {contentProps.action}
-                        </span>
-                    )}
-                />
+                {(!!snack && snack.children) || (
+                    <SnackbarContent
+                        className={classNames(
+                            classes.base,
+                            classes[`variant${capitalise(variant)}`],
+                            className,
+                        )}
+                        {...contentProps}
+                        aria-describedby="client-snackbar"
+                        message={(
+                            <span id="client-snackbar" className={classes.message}>
+                                {!hideIconVariant ? <Icon className={classes.icon} /> : null}
+                                {snack.message}
+                            </span>
+                        )}
+                        action={contentProps.action && (
+                            <span onClick={onClickHandler}>
+                                {contentProps.action}
+                            </span>
+                        )}
+                    />
+                )}
             </Snackbar>
         );
     }


### PR DESCRIPTION
Fixes #22 by rendering the `snack.children` if it exists.