### PR TITLE
Allow react components as message without react prop types error

### DIFF
--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -117,7 +117,10 @@ SnackbarItem.propTypes = {
         /**
          * Text of the snackbar/notification.
          */
-        message: PropTypes.string.isRequired,
+        message: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.node,
+        ]).isRequired,
         /**
          * Type of snackbar. defaulted to 'default'.
          */


### PR DESCRIPTION
You'll notice that the message param of enqueueSnackber allows react components such as `<span>I am <strong>STRONG!</strong></span>` to be passed in rather than just a string. It works perfectly fine too but a React prop invalidation error is thrown. This change stops that from happening.