### PR TITLE
Support Rendering a React.ReactNode as the `message`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export type CombinedClassKey = NotistackClassKey | SnackbarClassKey;
 
 export interface InjectedNotistackProps {
     onPresentSnackbar: (variant: VariantType, message: string) => void;
-    enqueueSnackbar: (message: string, options?: OptionsObject) => void;
+    enqueueSnackbar: (message: string | React.ReactNode, options?: OptionsObject) => void;
 }
 
 export function withSnackbar<P extends InjectedNotistackProps>(component: React.ComponentType<P>):


### PR DESCRIPTION
Currently, the notistack codebase can handle rendering a node as the 'message' - just like the material-ui Snackbar does. However, the current notistack type definitions prevent a user from being able to pass a React.ReactNode as the message parameter to the `enqueueSnackbar` method.

A use case for this is trying to use `ReactIntl` to show an internationalized message string in a snackbar. Before, it was not possible to render a `<FormattedMessage>` component inside a notistack snackbar. However, with this PR a user can now do something like:

```typescript
enqueueSnackbar(<FormattedMessage {...messages.success} />, {
    variant: 'success'
});
```

while still being able to pass a simple string when desired:

```typescript
enqueueSnackbar('hello notistack', {
    variant: 'success'
});
```

Currently, notistack supports setting the `children` property on the options, but this overrides all markup for the Snackbar, and does not allow a user to leverage the nice variant styles supplied by notistack.