### PR TITLE
Allow dismiss snackbars programmatically (#20)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
             4
         ],
         "react/destructuring-assignment": 0,
+        "react/jsx-closing-bracket-location": 0,
         "react/forbid-prop-types": 0,
         "react/sort-comp": 0,
         "react/jsx-filename-extension": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 Thanks to all contributers who improved notistack by opening an issue/PR.
 
-**@james-cordeiro**
+**@james-cordeiro @xiromoreira**
 * Add support to close snackbars programmatically [#20](https://github.com/iamhosseindhv/notistack/issues/20)
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 export type VariantType = 'default' | 'error' | 'success' | 'warning' | 'info';
 
 export interface OptionsObject extends Omit<SnackbarProps, 'open' | 'message' | 'classes'> {
+    key?: string | number;
     variant?: VariantType;
     onClickAction?: Function;
 }
@@ -22,7 +23,8 @@ export type CombinedClassKey = NotistackClassKey | SnackbarClassKey;
 
 export interface InjectedNotistackProps {
     onPresentSnackbar: (variant: VariantType, message: string) => void;
-    enqueueSnackbar: (message: string | React.ReactNode, options?: OptionsObject) => void;
+    enqueueSnackbar: (message: string | React.ReactNode, options?: OptionsObject) => string | number;
+    closeSnackbar: (key: string | number) => void
 }
 
 export function withSnackbar<P extends InjectedNotistackProps>(component: React.ComponentType<P>):

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -150,7 +150,10 @@ SnackbarItem.propTypes = {
         /**
          * Identifier of a given snakcbar.
          */
-        key: PropTypes.number.isRequired,
+        key: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number,
+        ]).isRequired,
         /**
          * Whether or not a snackbar is visible or hidden.
          */

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -158,7 +158,7 @@ class SnackbarProvider extends Component {
             <SnackbarContext.Provider value={this.handlePresentSnackbar}>
                 <SnackbarContextNext.Provider value={{
                     handleEnqueueSnackbar: this.handleEnqueueSnackbar,
-                    handleCloseSnackbar: this.handleCloseSnack
+                    handleCloseSnackbar: this.handleCloseSnack,
                 }}>
                     <Fragment>
                         {children}

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -53,15 +53,19 @@ class SnackbarProvider extends Component {
      * We can pass Material-ui Snackbar props for individual customisation.
      * @param {string} options.variant - type of the snackbar. default value is 'default'.
      * can be: (default, success, error, warning, info)
+     * @returns generated or user defined key referencing the new snackbar
      */
-    handleEnqueueSnackbar = (message, options) => {
+    handleEnqueueSnackbar = (message, { key, ...options }) => {
+        if (key === undefined || key === null) {
+            key = new Date().getTime() + Math.random();
+        }
         this.queue.push({
-            message,
+            message, key,
             ...options,
             open: true,
-            key: new Date().getTime() + Math.random(),
         });
         this.handleDisplaySnack();
+        return key;
     };
 
     /**
@@ -152,7 +156,10 @@ class SnackbarProvider extends Component {
 
         return (
             <SnackbarContext.Provider value={this.handlePresentSnackbar}>
-                <SnackbarContextNext.Provider value={this.handleEnqueueSnackbar}>
+                <SnackbarContextNext.Provider value={{
+                    handleEnqueueSnackbar: this.handleEnqueueSnackbar,
+                    handleCloseSnackbar: this.handleCloseSnack
+                  }}>
                     <Fragment>
                         {children}
                         {snacks.map((snack, index) => (

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -56,16 +56,16 @@ class SnackbarProvider extends Component {
      * @returns generated or user defined key referencing the new snackbar
      */
     handleEnqueueSnackbar = (message, { key, ...options }) => {
-        if (key === undefined || key === null) {
-            key = new Date().getTime() + Math.random();
-        }
+        const id = key || new Date().getTime() + Math.random();
         this.queue.push({
-            message, key,
+            key: id,
+            message,
             ...options,
             open: true,
         });
+
         this.handleDisplaySnack();
-        return key;
+        return id;
     };
 
     /**
@@ -159,7 +159,7 @@ class SnackbarProvider extends Component {
                 <SnackbarContextNext.Provider value={{
                     handleEnqueueSnackbar: this.handleEnqueueSnackbar,
                     handleCloseSnackbar: this.handleCloseSnack
-                  }}>
+                }}>
                     <Fragment>
                         {children}
                         {snacks.map((snack, index) => (

--- a/src/withSnackbar.js
+++ b/src/withSnackbar.js
@@ -5,11 +5,12 @@ const withSnackbar = Component => props => (
     <SnackbarContext.Consumer>
         {handlePresentSnackbar => (
             <SnackbarContextNext.Consumer>
-                {handleEnqueueSnackbar => (
+                {context => (
                     <Component
                         {...props}
                         onPresentSnackbar={handlePresentSnackbar}
-                        enqueueSnackbar={handleEnqueueSnackbar}
+                        enqueueSnackbar={context.handleEnqueueSnackbar}
+                        closeSnackbar={context.handleCloseSnackbar}
                     />
                 )}
             </SnackbarContextNext.Consumer>


### PR DESCRIPTION
With this changes enqueueSnackbar() will return the key so you can use it with closeSnackbar(key) which is now exposed to consumer components.

If the user has defined the key, it will be used instead of the auto-generated one, allowing to set notification ids based on the related data (so you don't have to handle a new id if you already have one).