### PR TITLE
Update Snackbar Content in place using key

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ options.onClickAction   type: func          required: false       defualt: dismi
 // You can pass material-ui Snackbar props here, and they will be applied to this individual snackbar.
 // for example, this particular snackbar will be dismissed after 1sec.
 options.autoHideDuration: 1000
+
+// Provide a unique string or number to maintain a snack's content. An example
+// is when the snackbar is showing progress and you want to see progress updated
+// on a single snack, rather than many snacks indicating each step.
+key             type:string|number  required: false
 ```
 **Note**: `onPresentSnackbar` has been now deprecated. Use `enqueueSnackbar` instead:
 ```javascript

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -148,9 +148,9 @@ SnackbarItem.propTypes = {
          */
         onClickAction: PropTypes.func,
         /**
-         * Identifier of a given snakcbar.
+         * Identifier of a given snackbar.
          */
-        key: PropTypes.number.isRequired,
+        key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
         /**
          * Whether or not a snackbar is visible or hidden.
          */

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -18,7 +18,7 @@ class SnackbarProvider extends Component {
             let index = i;
             let offset = 20;
             while (snacks[index - 1]) {
-                offset += snacks[index - 1].height + 16;
+                offset += (snacks[index - 1].height || 48) + 16;
                 index -= 1;
             }
             return offset;
@@ -53,13 +53,14 @@ class SnackbarProvider extends Component {
      * We can pass Material-ui Snackbar props for individual customisation.
      * @param {string} options.variant - type of the snackbar. default value is 'default'.
      * can be: (default, success, error, warning, info)
+     * @param {string|number} key - a unique id to allow modifying an existing snackbar notification
      */
-    handleEnqueueSnackbar = (message, options) => {
+    handleEnqueueSnackbar = (message, options, key) => {
         this.queue.push({
             message,
             ...options,
             open: true,
-            key: new Date().getTime() + Math.random(),
+            key: key || new Date().getTime() + Math.random(),
         });
         this.handleDisplaySnack();
     };
@@ -83,9 +84,11 @@ class SnackbarProvider extends Component {
     processQueue = () => {
         if (this.queue.length > 0) {
             const newOne = this.queue.shift();
-            this.setState(({ snacks }) => ({
-                snacks: [...snacks, newOne],
-            }));
+            this.setState(({ snacks }) => {
+                // remove all the snacks with the same key
+                const updated = snacks.filter(({ key }) => key !== newOne.key);
+                return { snacks: [...updated, newOne] };
+            });
         }
     };
 


### PR DESCRIPTION
a unique key can be passed to `enqueueSnackbar` to deduplicate snacks with the same key. this allows content to be updated on a given snack as long as that key is maintained by the caller.

- enqueuing without setting a manually generated key is not affected
- a snackbar item that is enqueued with a manually generated key will replace other items with the same key, effectively updating the content without creating a new notification pop

to see an example, wire up this code to component that has the `withSnackbar` context:

```
let i = 0;
setInterval(() => {
  this.props.enqueueSnackbar(`update this one: ${++i}`, { variant: 'success' }, 'myuniquekey');
}, 1000);
let k = 0;
setInterval(() => {
  this.props.enqueueSnackbar(`regular enqueue: ${++k}`, { variant: 'info' });
}, 2000);
```