### PR TITLE
Change 'offset' value in SnackbarProvider.js

### DIFF
--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -16,7 +16,7 @@ class SnackbarProvider extends Component {
         const { snacks } = this.state;
         return snacks.map((item, i) => {
             let index = i;
-            let offset = 20;
+            let offset = (window.innerWidth < 600) ? 0 : 20;
             while (snacks[index - 1]) {
                 offset += snacks[index - 1].height + 16;
                 index -= 1;


### PR DESCRIPTION
In mobile view, offset value '20' makes an empty space at bottom place.
However, original material-ui snackbar does not make empty space in the mobile view.
Therefore, I want to change this file like this.