### PR TITLE
Added ability to lock an item from dismissal via the locked flag

### DIFF
--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -97,10 +97,28 @@ class SnackbarProvider extends Component {
      * Hide oldest snackbar on the screen because there exists a new one which we have to display.
      */
     handleDismissOldest = () => {
+        let popped = false;
+
         this.setState(({ snacks }) => ({
             snacks: snacks
                 .filter(item => item.open === true)
-                .map((item, i) => (i === 0 ? { ...item, open: false } : { ...item })),
+                .map((item, i) => {
+                    if (!popped && !item.locked) {
+                        popped = true;
+                        if (item.onClose) {
+                            item.onClose(null, "maxsnack", item.key);
+                        }
+
+                        return {
+                            ...item,
+                            open: false,
+                        };
+                    }
+
+                    return {
+                        ...item,
+                    };
+                }),
         }));
     };
 


### PR DESCRIPTION

1. Added ability to lock an item from dismissal via the locked flag

We needed the ability to lock a snackbar message so that it wouldn't be dismissed when maxSnack was hit.

2. handleDismissOldest will now call items onClose

When an item was being dismissed because due to maxSnack we needed to know about it.  An items onClose event will now be called if this happens with the reason "maxsnack"