### PR TITLE
Use CSS for snackbar positioning rather than precomputed offset

### DIFF
--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -7,13 +7,13 @@ import Snackbar from '@material-ui/core/Snackbar';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
 import { styles, getTransitionStyles } from './SnackbarItem.styles';
 import {
-    capitalise,
     defaultAnchorOrigin,
     getTransitionDirection,
     getMuiClasses,
     TransitionComponent,
     variantIcon,
 } from './SnackbarItem.util';
+import capitalise from '../utils/capitalise';
 
 
 class SnackbarItem extends Component {

--- a/src/SnackbarItem/SnackbarItem.styles.js
+++ b/src/SnackbarItem/SnackbarItem.styles.js
@@ -40,10 +40,28 @@ export const styles = theme => ({
  * (when snackbars are stacked on top of eachother)
  * @returns {object}
  */
-export const getTransitionStyles = (offset, anchorOrigin) => (
-    Object.assign(
+export const getTransitionStyles = (offset, anchorOrigin) => {
+    const vertical = (anchorOrigin.vertical !== "center")? anchorOrigin.vertical : 'bottom';
+
+    return Object.assign(
         {
-            [anchorOrigin.vertical]: offset,
+            ['margin-'+vertical]: offset,
+            ...(() => {
+                if (anchorOrigin.horizontal !== 'center') {
+                    return {
+                        [anchorOrigin.horizontal]: 0,
+                    };
+                }
+                return {};
+            })(),
+            ...(() => {
+                if (anchorOrigin.vertical !== 'center') {
+                    return {
+                        [anchorOrigin.vertical]: 0,
+                    };
+                }
+                return {};
+            })(),
         },
         {
             WebKitTransition: `all ${TRANSITION_DOWN_DURATION}ms`,
@@ -53,5 +71,5 @@ export const getTransitionStyles = (offset, anchorOrigin) => (
             transition: `all ${TRANSITION_DOWN_DURATION}ms`,
             transitionDelay: `${TRANSITION_DELAY}ms`,
         },
-    )
-);
+    );
+};

--- a/src/SnackbarItem/SnackbarItem.util.js
+++ b/src/SnackbarItem/SnackbarItem.util.js
@@ -64,7 +64,9 @@ const defaultAnchorOrigin = {
 };
 
 const muiClasses = {
-    root: {},
+    root: {
+        position: 'relative',
+    },
     anchorOriginTopCenter: {},
     anchorOriginBottomCenter: {},
     anchorOriginTopRight: {},
@@ -85,12 +87,6 @@ const getTransitionDirection = (anchorOrigin = defaultAnchorOrigin) => {
 };
 
 /**
- * Capitalises a piece of string
- * @param {string} text
- */
-const capitalise = text => text.charAt(0).toUpperCase() + text.slice(1);
-
-/**
  * Filteres classes object and returns the keys that are allowed
  * in material-ui snackbar classes prop
  * @param {object} classes
@@ -105,7 +101,6 @@ const getMuiClasses = classes => (
 );
 
 export {
-    capitalise,
     defaultAnchorOrigin,
     getTransitionDirection,
     getMuiClasses,

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -1,9 +1,13 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { withStyles } from '@material-ui/core/styles';
 import { SnackbarContext, SnackbarContextNext } from './SnackbarContext';
 import { TRANSITION_DELAY, TRANSITION_DOWN_DURATION } from './utils/constants';
+import capitalise from './utils/capitalise';
 import SnackbarItem from './SnackbarItem';
 
+import { styles } from './SnackbarProvider.styles';
 
 class SnackbarProvider extends Component {
     state = {
@@ -15,13 +19,7 @@ class SnackbarProvider extends Component {
     get offsets() {
         const { snacks } = this.state;
         return snacks.map((item, i) => {
-            let index = i;
-            let offset = 20;
-            while (snacks[index - 1]) {
-                offset += snacks[index - 1].height + 16;
-                index -= 1;
-            }
-            return offset;
+            return 20;
         });
     }
 
@@ -162,7 +160,14 @@ class SnackbarProvider extends Component {
     };
 
     render() {
-        const { children, maxSnack, ...props } = this.props;
+        const {
+            children,
+            maxSnack,
+            classes,
+            anchorOrigin = {},
+            className,
+            ...props
+        } = this.props;
         const { snacks } = this.state;
 
         return (
@@ -173,17 +178,24 @@ class SnackbarProvider extends Component {
                 }}>
                     <Fragment>
                         {children}
-                        {snacks.map((snack, index) => (
-                            <SnackbarItem
-                                {...props}
-                                key={snack.key}
-                                snack={snack}
-                                offset={this.offsets[index]}
-                                onClose={this.handleCloseSnack}
-                                onExited={this.handleExitedSnack}
-                                onSetHeight={this.handleSetHeight}
-                            />
-                        ))}
+                        <div className={classNames(
+                            classes.root,
+                            classes[`anchorOrigin${capitalise(anchorOrigin.vertical)}${capitalise(anchorOrigin.horizontal)}`],
+                            className,
+                        )}>
+                            {snacks.map((snack, index) => (
+                                <SnackbarItem
+                                    {...props}
+                                    key={snack.key}
+                                    anchorOrigin={anchorOrigin}
+                                    snack={snack}
+                                    offset={this.offsets[index]}
+                                    onClose={this.handleCloseSnack}
+                                    onExited={this.handleExitedSnack}
+                                    onSetHeight={this.handleSetHeight}
+                                />
+                            ))}
+                        </div>
                     </Fragment>
                 </SnackbarContextNext.Provider>
             </SnackbarContext.Provider>
@@ -208,4 +220,4 @@ SnackbarProvider.defaultProps = {
     onExited: undefined,
 };
 
-export default SnackbarProvider;
+export default withStyles(styles)(SnackbarProvider);

--- a/src/SnackbarProvider.styles.js
+++ b/src/SnackbarProvider.styles.js
@@ -1,0 +1,84 @@
+/* Taken from @material-ui/core/Snackbar.js styles */
+
+export const styles = theme => {
+    const gutter = 24;
+    const top = { top: 0 };
+    const bottom = { bottom: 0 };
+    const right = { justifyContent: 'flex-end' };
+    const left = { justifyContent: 'flex-start' };
+    const topSpace = { top: 0 };
+    const bottomSpace = { bottom: 0 };
+    const rightSpace = { right: gutter };
+    const leftSpace = { left: gutter };
+    const center = {
+        left: '50%',
+        right: 'auto',
+        transform: 'translateX(-50%)',
+    };
+
+    return {
+        /* Styles applied to the root element. */
+        root: {
+            zIndex: theme.zIndex.snackbar,
+            position: 'fixed',
+            display: 'flex',
+            flexDirection: 'column',
+            left: 0,
+            right: 0,
+        },
+        /* Styles applied to the root element if `anchorOrigin={{ 'top', 'center' }}`. */
+        anchorOriginTopCenter: {
+            ...top,
+            [theme.breakpoints.up('md')]: {
+            ...center,
+            },
+        },
+        /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'center' }}`. */
+        anchorOriginBottomCenter: {
+            ...bottom,
+            [theme.breakpoints.up('md')]: {
+            ...center,
+            },
+        },
+        /* Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }}`. */
+        anchorOriginTopRight: {
+            ...top,
+            ...right,
+            [theme.breakpoints.up('md')]: {
+            left: 'auto',
+            ...topSpace,
+            ...rightSpace,
+            },
+        },
+        /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }}`. */
+        anchorOriginBottomRight: {
+            ...bottom,
+            ...right,
+            [theme.breakpoints.up('md')]: {
+            left: 'auto',
+            ...bottomSpace,
+            ...rightSpace,
+            },
+        },
+        /* Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }}`. */
+        anchorOriginTopLeft: {
+            ...top,
+            ...left,
+            [theme.breakpoints.up('md')]: {
+            right: 'auto',
+            ...topSpace,
+            ...leftSpace,
+            },
+        },
+        /* Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }}`. */
+        anchorOriginBottomLeft: {
+            ...bottom,
+            ...left,
+            [theme.breakpoints.up('md')]: {
+            right: 'auto',
+            ...bottomSpace,
+            ...leftSpace,
+            },
+        },
+    };
+};

--- a/src/utils/capitalise.js
+++ b/src/utils/capitalise.js
@@ -1,0 +1,7 @@
+/**
+ * Capitalises a piece of string
+ * @param {string} text
+ */
+const capitalise = text => text.charAt(0).toUpperCase() + text.slice(1);
+
+export default capitalise;


### PR DESCRIPTION
This was needed in order to support snackbars who have non-fixed height.

Right now offset is precomputed on mount and is never updated.

Instead of using an offset for each item this wraps the items in a container and positions the container instead.

Here is an example of my use case.

![screenshot from 2019-02-08 09-24-09](https://user-images.githubusercontent.com/339763/52491446-22793100-2b95-11e9-8a6c-d8ecb094019f.png)
![screenshot from 2019-02-08 09-23-19](https://user-images.githubusercontent.com/339763/52491452-2442f480-2b95-11e9-99e7-32fe7cea299c.png)

