### PR TITLE
Decreasing maxSnack from 2 -> 1 caused remaining snack to be dismissed

### DIFF
--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -74,7 +74,7 @@ class SnackbarProvider extends Component {
     handleDisplaySnack = () => {
         const { maxSnack } = this.props;
         const { snacks } = this.state;
-        if (snacks.length >= maxSnack) {
+        if (snacks.length > maxSnack) {
             return this.handleDismissOldest();
         }
         return this.processQueue();


### PR DESCRIPTION
Set maxSnack to 2.
Have two snacks present.
Call close on a snack.
Decrease maxSnack prop to 1.

Both snacks will disappear.
