### PR TITLE
[useSnackbar] Implemented Hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,8 @@ export interface InjectedNotistackProps {
 export function withSnackbar<P extends InjectedNotistackProps>(component: React.ComponentType<P>):
     React.ComponentClass<Omit<P, keyof InjectedNotistackProps>> & { WrappedComponent: React.ComponentType<P> };
 
+export function useSnackbar(): InjectedNotistackProps;
+
 export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
 
 /** all MUI props, including class keys for notistack and MUI with additional notistack props */

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { default as SnackbarProvider } from './SnackbarProvider';
 export { default as withSnackbar } from './withSnackbar';
+export { default as useSnackbar } from './useSnackbar';

--- a/src/useSnackbar.js
+++ b/src/useSnackbar.js
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+import { SnackbarContext, SnackbarContextNext } from './SnackbarContext';
+
+const useSnackbar = () => {
+    const handlePresentSnackbar = useContext(SnackbarContext);
+    const context = useContext(SnackbarContextNext);
+
+    return {
+        onPresentSnackbar: handlePresentSnackbar,
+        enqueueSnackbar: context.handleEnqueueSnackbar,
+        closeSnackbar: context.handleCloseSnackbar,
+    };
+};
+
+export default useSnackbar;


### PR DESCRIPTION
This pull request introduce `useSnackbar` hook which use `useContext` hook of React to provide the same properties of `withSnackbar`.

I'm already successfully using it in a React TypeScript project.