### PR TITLE
Add material-ui to the list of npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "react",
         "javascript",
         "material-ui",
-        "material ui",
         "toast",
         "redux",
         "snackbar",


### PR DESCRIPTION
I would like to enable a third-party component search for Material-UI components like Gatsby is doing it with its plugins page: https://www.gatsbyjs.org/plugins/.