### PR TITLE
Add example files for Mobx

### DIFF
--- a/examples/mobx-example/App.js
+++ b/examples/mobx-example/App.js
@@ -1,0 +1,36 @@
+import React, {Fragment} from "react";
+import {inject, observer} from "mobx-react";
+import Typography from "@material-ui/core/Typography";
+import Button from "@material-ui/core/Button";
+import Notifier from "./Notifier";
+
+const App = inject("store")(observer(
+    class App extends React.Component {
+        handleClick = () => {
+            this.props.store.addNote({
+                message: "Notistack is great with mobx!",
+                options: {
+                    variant: "info"
+                }
+            });
+        };
+
+        render() {
+            return (
+                <Fragment>
+                    <Notifier/>
+                    <Typography variant="h4" gutterBottom>
+                        Notistack mobx example
+                    </Typography>
+                    <Button variant="contained" onClick={this.handleClick}>
+                        Display snackbar
+                    </Button>
+                </Fragment>
+            );
+        }
+
+    }
+));
+
+
+export default App;

--- a/examples/mobx-example/Notifier.js
+++ b/examples/mobx-example/Notifier.js
@@ -1,0 +1,40 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable import/no-unresolved */
+import React from "react";
+import {withSnackbar} from "notistack";
+import {inject, observer} from "mobx-react";
+import {autorun} from "mobx";
+
+const Notifier = inject("store")(observer(
+    class Notifier extends React.Component {
+        displayed = [];
+
+        storeDisplayed = id => {
+            this.displayed = [...this.displayed, id];
+        };
+
+        componentDidMount() {
+            autorun(() => {
+                const {notifications = []} = this.props.store;
+
+                notifications.forEach(notification => {
+                    // Do nothing if snackbar is already displayed
+                    if (this.displayed.includes(notification.key)) return;
+                    // Display snackbar using notistack
+                    this.props.enqueueSnackbar(notification.message, notification.options);
+                    // Keep track of snackbars that we've displayed
+                    this.storeDisplayed(notification.key);
+                    // Dispatch action to remove snackbar from mobx store
+                    this.props.store.removeNote(notification.key);
+                });
+            })
+        }
+
+        render() {
+            return null;
+        }
+    }
+    )
+);
+
+export default withSnackbar(Notifier);

--- a/examples/mobx-example/index.js
+++ b/examples/mobx-example/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+import {render} from "react-dom";
+import {Provider} from "mobx-react";
+import {SnackbarProvider} from "notistack";
+import store from "./store/store";
+import App from "./App";
+
+render(
+    <Provider store={store}>
+        <SnackbarProvider>
+            <App/>
+        </SnackbarProvider>
+    </Provider>,
+    document.getElementById("root")
+);

--- a/examples/mobx-example/package.json
+++ b/examples/mobx-example/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "notistack-mobx-example",
+  "description": "Mobx example for notistack",
+  "homepage": "https://www.iamhosseindhv.com/notistack",
+  "repository": {
+    "url": "git+https://github.com/iamhosseindhv/notistack.git",
+    "type": "git"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "react": "16.4.2",
+    "react-dom": "16.4.2",
+    "react-scripts": "1.1.4",
+    "mobx": "^5.9.0",
+    "mobx-react": "^5.4.3",
+    "notistack": "^0.4.2",
+    "@material-ui/core": "3.4.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/examples/mobx-example/public/index.html
+++ b/examples/mobx-example/public/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>React App</title>
+</head>
+
+<body>
+<noscript>
+    You need to enable JavaScript to run this app.
+</noscript>
+<div id="root"></div>
+<!--
+  This HTML file is a template.
+  If you open it directly in the browser, you will see an empty page.
+
+  You can add webfonts, meta tags, or analytics to this file.
+  The build step will place the bundled scripts into the <body> tag.
+
+  To begin the development, run `npm start` or `yarn start`.
+  To create a production bundle, use `npm run build` or `yarn build`.
+-->
+</body>
+
+</html>

--- a/examples/mobx-example/store/store.js
+++ b/examples/mobx-example/store/store.js
@@ -1,0 +1,19 @@
+import {action, extendObservable} from "mobx";
+
+const Store = function () {
+
+    extendObservable(this, {
+        notifications: [],
+        addNote: action(note => {
+            this.notifications.push({
+                key: new Date().getTime() + Math.random(),
+                ...note,
+            });
+        }),
+        removeNote: action(note => {
+            this.notifications.remove(note)
+        })
+    });
+};
+
+export default new Store();


### PR DESCRIPTION
Adds another example using Mobx which matches as closely as possible to the existing Redux example to demonstrate how users could use an alternate state management solution with Notistack.