### PR TITLE
Remove duplicate declaration in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,8 +29,6 @@ export function withSnackbar<P extends withSnackbarProps>(component: React.Compo
 
 export function useSnackbar(): withSnackbarProps;
 
-export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
-
 // all material-ui props, including class keys for notistack and material-ui with additional notistack props
 export interface SnackbarProviderProps extends Omit<SnackbarProps, 'open' | 'message' | 'classes'> {
     classes?: Partial<ClassNameMap<CombinedClassKey>>;


### PR DESCRIPTION
Fix

```ts
node_modules/notistack/index.d.ts:32:13 - error TS2300: Duplicate identifier 'ClassNameMap'.

32 export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
               ~~~~~~~~~~~~
```