### PR TITLE
Remove duplicate `ClassNameMap` TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,8 +29,6 @@ export function withSnackbar<P extends withSnackbarProps>(component: React.Compo
 
 export function useSnackbar(): withSnackbarProps;
 
-export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
-
 // all material-ui props, including class keys for notistack and material-ui with additional notistack props
 export interface SnackbarProviderProps extends Omit<SnackbarProps, 'open' | 'message' | 'classes'> {
     classes?: Partial<ClassNameMap<CombinedClassKey>>;


### PR DESCRIPTION
Resolves https://github.com/iamhosseindhv/notistack/issues/105.