### PR TITLE
Support for multiple custom actions in snacks

### DIFF
--- a/examples/redux-example/App.js
+++ b/examples/redux-example/App.js
@@ -10,8 +10,15 @@ const App = (props) => {
     const handleClick = () => {
         props.enqueueSnackbar({
             message: 'Failed fetching data.',
+            persist: true,
             options: {
                 variant: 'warning',
+                getAction: (onClose) => (
+                    <Fragment>
+                        <Button onClick={() => alert('These are your details')}>Details</Button>
+                        <Button onClick={onClose}>Close</Button>
+                    </Fragment>
+                )
             },
         });
     };

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export interface OptionsObject extends Omit<SnackbarProps, 'open' | 'message' | 
     persist?: boolean;
     onClickAction?: Function;
     preventDuplicate?: boolean;
+    getAction: (onClose: (event: HTMLElement, key: string) => void) => React.ReactNode;
 }
 
 export type NotistackClassKey = 'variantSuccess' | 'variantError' | 'variantInfo' | 'variantWarning';

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -82,8 +82,11 @@ class SnackbarItem extends Component {
 
         const anchOrigin = singleSnackProps.anchorOrigin || anchorOrigin;
 
-        const actualAction = contentProps.action ||
-            (contentProps.getAction && contentProps.getAction(this.handleClose(key)));
+        const actualAction = (
+            <span onClick={onClickHandler}>
+                {contentProps.action}
+            </span>
+        ) || (contentProps.getAction && contentProps.getAction(this.handleClose(key)));
 
         return (
             <RootRef rootRef={this.ref}>

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -74,12 +74,16 @@ class SnackbarItem extends Component {
             ...otherContentProps,
             ...singleSnackProps.ContentProps,
             action: snack.action || contentAction || action,
+            getAction: snack.getAction,
         };
 
         let onClickHandler = snack.action ? singleOnClickAction : onClickAction;
         onClickHandler = onClickHandler || this.handleClose(key);
 
         const anchOrigin = singleSnackProps.anchorOrigin || anchorOrigin;
+
+        const actualAction = contentProps.action ||
+            (contentProps.getAction && contentProps.getAction(this.handleClose(key)));
 
         return (
             <RootRef rootRef={this.ref}>
@@ -117,11 +121,7 @@ class SnackbarItem extends Component {
                                     {snack.message}
                                 </span>
                             )}
-                            action={contentProps.action && (
-                                <span onClick={onClickHandler}>
-                                    {contentProps.action}
-                                </span>
-                            )}
+                            action={actualAction}
                         />
                     )}
                 </Snackbar>
@@ -167,6 +167,11 @@ SnackbarItem.propTypes = {
          * Whether or not a snackbar is visible or hidden.
          */
         open: PropTypes.bool.isRequired,
+
+        /**
+         * Custom action generator, which accepts `onClose` handler to close current snack.
+         */
+        getAction: PropTypes.func,
     }).isRequired,
     /**
      * Little icon that is displayed at left corner of a snackbar.


### PR DESCRIPTION
See https://github.com/iamhosseindhv/notistack/issues/107 for details.

My design decisions:

1. The only reliable way to ensure user is able to close the snack – to provide user's `action` with our internal `onClose` handler. This could be done via abstracting `action` into a generator function.
2. I also updated Redux example so you can see implementation from the user's perspective.
3. The old behavior is preserved, so no regression is introduced by this PR.

> Notes: I had to create `src` folder in `redux-example` and move corresponding files into it so the example could actually work.