### PR TITLE
fix: add hoist-non-react-statics

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
         "react-dom": "^16.8.0"
     },
     "dependencies": {
-        "prop-types": "^15.6.2",
-        "classnames": "^2.2.6"
+        "classnames": "^2.2.6",
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.6.2"
     },
     "bugs": {
         "url": "https://github.com/iamhosseindhv/notistack/issues"

--- a/src/withSnackbar.js
+++ b/src/withSnackbar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import SnackbarContext from './SnackbarContext';
 
 const withSnackbar = (Component) => {
@@ -13,7 +14,7 @@ const withSnackbar = (Component) => {
             )}
         </SnackbarContext.Consumer>
     );
-
+    hoistNonReactStatics(WrappedComponent, Component);
     WrappedComponent.displayName = `withSnackbar(${Component.displayName || Component.name || 'Component'})`;
 
     return WrappedComponent;


### PR DESCRIPTION
the withSnackbar HOC doesn't copy non-react specific statics from  component to the wrapper, it may introduce bugs. For example, when using `next.js` page component has static method `getInitialProps`, it should be called each time a page is requested, but when using withSnackbar HOC, this function is no more called.