### PR TITLE
Allow enqueueSnackbar children to be a function and pass the snack key

### DIFF
--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -83,6 +83,11 @@ class SnackbarItem extends Component {
             finalAction = contentProps.action(key);
         }
 
+        let snackChildren = snack.children;
+        if (snackChildren && typeof snackChildren === 'function') {
+            snackChildren = snackChildren(key);
+        }
+
         return (
             <RootRef rootRef={this.ref}>
                 <Snackbar
@@ -103,7 +108,7 @@ class SnackbarItem extends Component {
                     onClose={this.handleClose(key)}
                     onExited={this.handleExited(key)}
                 >
-                    {snack.children || (
+                    {snackChildren || (
                         <SnackbarContent
                             className={classNames(
                                 classes.base,


### PR DESCRIPTION
We have a lot of custom, fancy snack messages that we need to be disabled in our application. These messages also have dismiss actions inside of them. The children property needs to pass the key to it, so that we can properly close the message.

This PR checks to see if the children property is a function and then will invoke that function passing the key property in. Existing functionality is still in tact, this just further enhances the customization.

Thank you,
Joshua