### PR TITLE
Should inherit autoHideDuration from enqueueSnackbar options

### DIFF
--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -76,6 +76,12 @@ class SnackbarItem extends Component {
             action: singleAction || singleContentProps.action || contentAction || action,
         };
 
+        let autoHideDuration = singleSnackProps.autoHideDuration || 5000;
+
+        if(persist) {
+            autoHideDuration = undefined;
+        }
+
         const anchOrigin = singleSnackProps.anchorOrigin || anchorOrigin;
 
         let finalAction = contentProps.action;
@@ -91,7 +97,7 @@ class SnackbarItem extends Component {
         return (
             <RootRef rootRef={this.ref}>
                 <Snackbar
-                    autoHideDuration={5000}
+                    autoHideDuration={autoHideDuration}
                     anchorOrigin={anchOrigin}
                     TransitionComponent={TransitionComponent}
                     TransitionProps={{


### PR DESCRIPTION
Hi,

I found a bug related to the autoHideDuration option, that should be available for configuration through the enqueueSnackbar options.

It's currently hard coded to 5000 ms. This PR fixes that, and allows autoHideDuration to be set through enqueueSnackbar options as described by the docs.