### PR TITLE
Add `types` path for better IDE support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.8.4",
     "description": "Highly customizable notification snackbars (toasts) that can be stacked on top of each other",
     "main": "build/index",
+    "types": "build/index",
     "license": "MIT",
     "author": {
         "name": "Hossein Dehnokhalaji",


### PR DESCRIPTION
Currently without a `types` path IDEs like Webstorm cannot resolve the `index.d.ts` to get any type information.

Adding the `types` path would remove the need for the current workaround of `import { withSnackbar } from 'notistack/build'` in order to get that type information.