### PR TITLE
Fixed SnackbarProvider propType for transitionComponent

### DIFF
--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -336,7 +336,7 @@ SnackbarProvider.propTypes = {
     /**
      * The component used for the transition.
      */
-    TransitionComponent: PropTypes.elementType,
+    TransitionComponent: PropTypes.func,
     /**
      * The duration for the transition, in milliseconds.
      * You may specify a single timeout for all transitions, or individually with an object.


### PR DESCRIPTION
This fixes: #129

After this, propType error for `SnackbarProvider` doesn't appear anymore.