### PR TITLE
ISSUE-132 ISSUE-141 Make resizable snackbars

### DIFF
--- a/src/SnackbarContainer/SnackbarContainer.js
+++ b/src/SnackbarContainer/SnackbarContainer.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { withStyles } from '@material-ui/core/styles';
+import styles from './SnackbarContainer.styles';
+import { RENDER_VARIANTS } from '../utils/constants';
+
+const SnackbarContainer = ({ children, classes, renderVariant, anchorOrigin }) => {
+    const className = classNames({
+        [classes.root]: true,
+        [classes.reverseColumns]: anchorOrigin.vertical === 'bottom',
+        [classes.top]: anchorOrigin.vertical === 'top',
+        [classes.bottom]: anchorOrigin.vertical === 'bottom',
+        [classes.left]: anchorOrigin.horizontal === 'left',
+        [classes.center]: anchorOrigin.horizontal === 'center',
+        [classes.right]: anchorOrigin.horizontal === 'right',
+    });
+    return (
+        renderVariant === RENDER_VARIANTS.wrapped
+            ? <div className={className}>{children}</div>
+            : children
+    );
+};
+
+SnackbarContainer.propTypes = {
+    children: PropTypes.node,
+    classes: PropTypes.object,
+    renderVariant: PropTypes.oneOf(Object.keys(RENDER_VARIANTS)),
+    anchorOrigin: PropTypes.shape({
+        horizontal: PropTypes.oneOf(['left', 'center', 'right']).isRequired,
+        vertical: PropTypes.oneOf(['top', 'bottom']).isRequired,
+    }),
+};
+
+export default withStyles(styles)(SnackbarContainer);

--- a/src/SnackbarContainer/SnackbarContainer.styles.js
+++ b/src/SnackbarContainer/SnackbarContainer.styles.js
@@ -1,0 +1,36 @@
+
+
+const styles = theme => ({
+    root: {
+        display: 'flex',
+        maxHeight: '100vh',
+        maxWidth: '100vw',
+        position: 'fixed',
+        flexDirection: 'column',
+        padding: 0,
+        transition: theme.transitions.create(['padding']),
+        [theme.breakpoints.up('md')]: {
+            padding: typeof theme.spacing === 'function' ? theme.spacing(3) : theme.spacing.unit * 3,
+        },
+    },
+    reverseColumns: {
+        flexDirection: 'column-reverse',
+    },
+    top: {
+        top: 0,
+    },
+    bottom: {
+        bottom: 0,
+    },
+    left: {
+        left: 0,
+    },
+    center: {
+        [theme.breakpoints.up('md')]: { left: '50%', transform: 'translateX(-50%)' },
+    },
+    right: {
+        right: 0,
+    },
+});
+
+export default styles;

--- a/src/SnackbarContainer/index.js
+++ b/src/SnackbarContainer/index.js
@@ -1,0 +1,3 @@
+import SnackbarContainer from './SnackbarContainer';
+
+export default SnackbarContainer;

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -6,7 +6,8 @@ import RootRef from '@material-ui/core/RootRef';
 import Snackbar from '@material-ui/core/Snackbar';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
 import { styles, getTransitionStyles } from './SnackbarItem.styles';
-import { capitalise, getMuiClasses, getTransitionDirection } from './SnackbarItem.util';
+import { capitalise, getTransitionDirection, getSnackbarClasses } from './SnackbarItem.util';
+import { RENDER_VARIANTS } from '../utils/constants';
 
 
 class SnackbarItem extends Component {
@@ -47,6 +48,8 @@ class SnackbarItem extends Component {
             snack,
             style,
             onSetHeight,
+            renderVariant,
+            dense,
             ...other
         } = this.props;
 
@@ -70,7 +73,16 @@ class SnackbarItem extends Component {
         };
 
         const ariaDescribedby = contentProps['aria-describedby'] || 'client-snackbar';
-        const anchOrigin = singleSnackProps.anchorOrigin || anchorOrigin;
+
+        const anchOrigin = {
+            [RENDER_VARIANTS.default]: singleSnackProps.anchorOrigin || anchorOrigin,
+            [RENDER_VARIANTS.wrapped]: anchorOrigin,
+        }[renderVariant];
+
+        const transitionStyles = {
+            [RENDER_VARIANTS.default]: getTransitionStyles(offset, anchOrigin),
+            [RENDER_VARIANTS.wrapped]: {},
+        }[renderVariant];
 
         let finalAction = contentProps.action;
         if (typeof finalAction === 'function') {
@@ -85,18 +97,18 @@ class SnackbarItem extends Component {
         return (
             <RootRef rootRef={this.ref}>
                 <Snackbar
-                    anchorOrigin={anchOrigin}
                     TransitionProps={{
                         direction: getTransitionDirection(anchOrigin),
                     }}
                     style={{
                         ...style,
-                        ...getTransitionStyles(offset, anchOrigin),
+                        ...transitionStyles,
                     }}
                     {...other}
                     {...singleSnackProps}
+                    anchorOrigin={anchOrigin}
                     open={snack.open}
-                    classes={getMuiClasses(classes)}
+                    classes={getSnackbarClasses(classes, renderVariant, dense, anchOrigin)}
                     onClose={this.handleClose(key)}
                     onExited={this.handleExited(key)}
                 >
@@ -150,6 +162,8 @@ SnackbarItem.propTypes = {
     }).isRequired,
     hideIconVariant: PropTypes.bool.isRequired,
     preventDuplicate: PropTypes.bool.isRequired,
+    renderVariant: PropTypes.oneOf(Object.keys(RENDER_VARIANTS)).isRequired,
+    dense: PropTypes.bool.isRequired,
     onSetHeight: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     onExited: PropTypes.func.isRequired,

--- a/src/SnackbarItem/SnackbarItem.styles.js
+++ b/src/SnackbarItem/SnackbarItem.styles.js
@@ -1,7 +1,7 @@
 import green from '@material-ui/core/colors/green';
 import amber from '@material-ui/core/colors/amber';
 import { muiClasses } from './SnackbarItem.util';
-import { TRANSITION_DELAY, TRANSITION_DOWN_DURATION } from '../utils/constants';
+import { TRANSITION_DELAY, TRANSITION_DOWN_DURATION, SNACKBAR_INDENTS } from '../utils/constants';
 
 
 export const styles = theme => ({
@@ -30,6 +30,38 @@ export const styles = theme => ({
     message: {
         display: 'flex',
         alignItems: 'center',
+    },
+    wrappedRenderVariant: {
+        position: 'relative',
+        transform: 'translateX(0)',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        '&:nth-last-child(1n+2)': {
+            marginBottom: SNACKBAR_INDENTS.default.snackbar,
+        },
+    },
+    wrappedRenderVariantReverseFirstChild: {
+        '&:nth-last-child(1n+2)': {
+            marginBottom: 0,
+        },
+        '&:nth-child(1n+2)': {
+            marginBottom: SNACKBAR_INDENTS.default.snackbar,
+        },
+    },
+    wrappedRenderVariantDense: {
+        '&:nth-last-child(1n+2)': {
+            marginBottom: SNACKBAR_INDENTS.dense.snackbar,
+        },
+    },
+    wrappedRenderVariantReverseFirstChildDense: {
+        '&:nth-last-child(1n+2)': {
+            marginBottom: 0,
+        },
+        '&:nth-child(1n+2)': {
+            marginBottom: SNACKBAR_INDENTS.dense.snackbar,
+        },
     },
 });
 

--- a/src/SnackbarItem/SnackbarItem.util.js
+++ b/src/SnackbarItem/SnackbarItem.util.js
@@ -1,4 +1,5 @@
-import { defaultAnchorOrigin } from '../utils/constants';
+import classNames from 'classnames';
+import { defaultAnchorOrigin, RENDER_VARIANTS } from '../utils/constants';
 
 const DIRECTION = {
     right: 'left',
@@ -47,3 +48,24 @@ export const getMuiClasses = classes => (
             [key]: classes[key],
         }), {})
 );
+
+/**
+ * Add wrappedRenderVariant class to root classes of Snackbar if renderVariant is "wrapped"
+ * @param {object} classes
+ * @param {RENDER_VARIANTS} renderVariant
+ * @return {object}
+ */
+export const getSnackbarClasses = (classes, renderVariant, dense, anchOrigin) => {
+    const snackbarMuiClasses = getMuiClasses(classes);
+    const rootClasses = classNames({
+        [snackbarMuiClasses.root]: true,
+        [classes.wrappedRenderVariant]: renderVariant === RENDER_VARIANTS.wrapped,
+        [classes.wrappedRenderVariantDense]: renderVariant === RENDER_VARIANTS.wrapped && dense,
+        [classes.wrappedRenderVariantReverseFirstChild]: renderVariant === RENDER_VARIANTS.wrapped && anchOrigin.vertical === 'bottom',
+        [classes.wrappedRenderVariantReverseFirstChildDense]: renderVariant === RENDER_VARIANTS.wrapped && dense && anchOrigin.vertical === 'bottom',
+    });
+    return {
+        ...snackbarMuiClasses,
+        ...{ root: rootClasses },
+    };
+};

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -2,10 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Slide from '@material-ui/core/Slide';
 import SnackbarContext from './SnackbarContext';
-import { TRANSITION_DELAY, TRANSITION_DOWN_DURATION, MESSAGES, iconVariant } from './utils/constants';
+import { TRANSITION_DELAY, TRANSITION_DOWN_DURATION, MESSAGES, iconVariant, RENDER_VARIANTS, SNACKBAR_INDENTS } from './utils/constants';
 import SnackbarItem from './SnackbarItem';
+import SnackbarContainer from './SnackbarContainer';
 import warning from './utils/warning';
-
 
 class SnackbarProvider extends Component {
     constructor(props) {
@@ -26,8 +26,8 @@ class SnackbarProvider extends Component {
         return snacks.map((item, i) => {
             let index = i;
             const { view: viewOffset, snackbar: snackbarOffset } = this.props.dense
-                ? { view: 0, snackbar: 4 }
-                : { view: 20, snackbar: 12 };
+                ? SNACKBAR_INDENTS.dense
+                : SNACKBAR_INDENTS.default;
             let offset = viewOffset;
             while (snacks[index - 1]) {
                 const snackHeight = snacks[index - 1].height || 48;
@@ -199,24 +199,29 @@ class SnackbarProvider extends Component {
     };
 
     render() {
-        const { children, maxSnack, dense, ...props } = this.props;
+        const { children, maxSnack, dense, renderVariant, anchorOrigin, ...props } = this.props;
         const { contextValue, snacks } = this.state;
 
         return (
             <SnackbarContext.Provider value={contextValue}>
                 {children}
-                {snacks.map((snack, index) => (
-                    <SnackbarItem
-                        {...props}
-                        key={snack.key}
-                        snack={snack}
-                        offset={this.offsets[index]}
-                        iconVariant={Object.assign(iconVariant, this.props.iconVariant)}
-                        onClose={this.handleCloseSnack}
-                        onExited={this.handleExitedSnack}
-                        onSetHeight={this.handleSetHeight}
-                    />
-                ))}
+                <SnackbarContainer renderVariant={renderVariant} anchorOrigin={anchorOrigin}>
+                    {snacks.map((snack, index) => (
+                        <SnackbarItem
+                            {...props}
+                            anchorOrigin={anchorOrigin}
+                            key={snack.key}
+                            snack={snack}
+                            offset={this.offsets[index]}
+                            iconVariant={Object.assign(iconVariant, this.props.iconVariant)}
+                            onClose={this.handleCloseSnack}
+                            onExited={this.handleExitedSnack}
+                            onSetHeight={this.handleSetHeight}
+                            renderVariant={renderVariant}
+                            dense={dense}
+                        />
+                    ))}
+                </SnackbarContainer>
             </SnackbarContext.Provider>
         );
     }
@@ -346,6 +351,11 @@ SnackbarProvider.propTypes = {
         PropTypes.number,
         PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
     ]),
+    /**
+     * "default" - render snackbars by default without wrapped (as in material-ui)
+     * "wrapped" - render snackbars in fixed wrapper
+     */
+    renderVariant: PropTypes.oneOf(RENDER_VARIANTS),
 };
 
 SnackbarProvider.defaultProps = {
@@ -360,6 +370,7 @@ SnackbarProvider.defaultProps = {
     },
     autoHideDuration: 5000,
     TransitionComponent: Slide,
+    renderVariant: RENDER_VARIANTS.default,
 };
 
 export default SnackbarProvider;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,8 @@ type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
 
 export type VariantType = 'default' | 'error' | 'success' | 'warning' | 'info';
 
+export type RenderVariants = 'default'| 'wrapped';
+
 export interface OptionsObject extends Omit<SnackbarProps, 'open' | 'message' | 'classes'> {
     key?: string | number;
     variant?: VariantType;
@@ -40,6 +42,7 @@ export interface SnackbarProviderProps extends Omit<SnackbarProps, 'open' | 'mes
     preventDuplicate?: boolean;
     dense?: boolean;
     action?: SnackbarContentProps['action'] | ((key: OptionsObject['key']) => React.ReactNode);
+    renderVariant?: RenderVariants;
 }
 
 export const SnackbarProvider: React.ComponentType<SnackbarProviderProps>;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -60,3 +60,13 @@ export const TRANSITION_DOWN_DURATION = 200;
 export const MESSAGES = {
     NO_PERSIST_ALL: 'WARNING - notistack: Reached maxSnack while all enqueued snackbars have \'persist\' flag. Notistack will dismiss the oldest snackbar anyway to allow other ones in the queue to be presented.',
 };
+
+export const RENDER_VARIANTS = {
+    default: 'default',
+    wrapped: 'wrapped',
+};
+
+export const SNACKBAR_INDENTS = {
+    default: { view: 20, snackbar: 12 },
+    dense: { view: 0, snackbar: 4 },
+};


### PR DESCRIPTION
Fixed #132 
Fixed #141 
 
### renderVariant

To most compatibility with current notistack versions i made `renderVariant` property of SnackbarProvider that can be `default` or `wrapped`.

Example:

```javascript
<SnackbarProvider autoHideDuration={null}
                        renderVariant="wrapped"
                        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                        dense={dense}>

        {children}
      </SnackbarProvider>
```

When `renderVariant` is `wrapped` snackbars will wrapped in container and snacks will resizible.
When `renderVariant` is `default` snackbars will works without this changes (like current version).

May be in future `renderVariant` might be deleted and notistack will has `wrapped` renderVariant by default.

![notistack](https://user-images.githubusercontent.com/8006957/64918046-565aab80-d7a1-11e9-8e96-c01885368cad.gif)