### PR TITLE
Prevent processing on unmount

### DIFF
--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -21,6 +21,10 @@ class SnackbarProvider extends Component {
 
     queue = [];
 
+    componentWillUnmount() {
+        this.queue = []
+    }
+
     /**
      * Adds a new snackbar to the queue to be presented.
      * @param {string} message - text of the notification


### PR DESCRIPTION
Tiny fix. In normal app, it would be surely rare for Provider to unmount, but in tests, it can happen fairly often and cause an ugly warning in tests output.

![image](https://user-images.githubusercontent.com/1096340/65870624-e8a3a780-e37c-11e9-835c-0502cdcdfcf9.png)
