### PR TITLE
Fix Redux sample error

### DIFF
--- a/examples/redux-example/Notifier.js
+++ b/examples/redux-example/Notifier.js
@@ -12,42 +12,33 @@ class Notifier extends Component {
         this.displayed = [...this.displayed, id];
     };
 
-    shouldComponentUpdate({ notifications: newSnacks = [] }) {
-        if (!newSnacks.length) {
-            this.displayed = [];
-            return false;
-        }
 
-        const { notifications: currentSnacks } = this.props;
-        let notExists = false;
-        for (let i = 0; i < newSnacks.length; i += 1) {
-            const newSnack = newSnacks[i];
-            if (newSnack.dismissed) {
-                this.props.closeSnackbar(newSnack.key);
-                this.props.removeSnackbar(newSnack.key);
-            }
-
-            if (notExists) continue;
-            notExists = notExists || !currentSnacks.filter(({ key }) => newSnack.key === key).length;
-        }
-        return notExists;
+    removeDisplayed = (id) => {
+        this.displayed = this.displayed.filter(key => id !== key)
     }
 
     componentDidUpdate() {
         const { notifications = [] } = this.props;
 
-        notifications.forEach(({ key, message, options = {} }) => {
+        notifications.forEach(({ key, message, options = {}, dismissed = false }) => {
+            if (dismissed) {
+                this.props.closeSnackbar(key)
+                return
+            }
             // Do nothing if snackbar is already displayed
             if (this.displayed.includes(key)) return;
             // Display snackbar using notistack
             this.props.enqueueSnackbar(message, {
+                key,
                 ...options,
                 onClose: (event, reason, key) => {
                     if (options.onClose) {
                         options.onClose(event, reason, key);
                     }
-                    // Dispatch action to remove snackbar from redux store
+                },
+                onExited: (event, key) => {
                     this.props.removeSnackbar(key);
+                    this.removeDisplayed(key)
                 }
             });
             // Keep track of snackbars that we've displayed


### PR DESCRIPTION
Fix the error that the Redux example does not close properly when multiple notifications are displayed.

This error causes when multiple notifications are displayed. Only the latest one can be closed properly.