### PR TITLE
Allow 0 as a snackbar key identifier

### DIFF
--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -57,7 +57,7 @@ class SnackbarProvider extends Component {
             }
         }
 
-        const id = typeof key !== 'undefined' ? key : new Date().getTime() + Math.random();
+        const id = key || key === 0 ? key : new Date().getTime() + Math.random();
         const snack = {
             key: id,
             ...options,

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -57,7 +57,7 @@ class SnackbarProvider extends Component {
             }
         }
 
-        const id = key || new Date().getTime() + Math.random();
+        const id = typeof key !== 'undefined' ? key : new Date().getTime() + Math.random();
         const snack = {
             key: id,
             ...options,


### PR DESCRIPTION
At the moment, setting the `key` option to `0` will not respect it, and generate a random `id` based on `new Date().getTime() + Math.random()`.

This fix will check if the value of `key` is `undefined` before defaulting to auto-generating the `id`.

A specific use case for this would be when receiving payloads from an external source (like a subscription service), where the `id` could possibly start at `0`.