### PR TITLE
notification can override provider's preventDup

### DIFF
--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -49,7 +49,7 @@ class SnackbarProvider extends Component {
      * @returns generated or user defined key referencing the new snackbar or null
      */
     enqueueSnackbar = (message, { key, preventDuplicate, ...options } = {}) => {
-        if (preventDuplicate || this.props.preventDuplicate) {
+        if ((preventDuplicate === undefined && this.props.preventDuplicate) || preventDuplicate) {
             const inQueue = this.queue.findIndex(item => item.message === message) > -1;
             const inView = this.state.snacks.findIndex(item => item.message === message) > -1;
             if (inQueue || inView) {


### PR DESCRIPTION
Currently if a provider has `preventDuplicates={true}`, then duplicates will be prevented even if a individual notification has `preventDuplicates` explicitly set to `false`. 

This PR changes that behavior, so duplicates will never be prevented for some notification if it has `preventDuplicates: false`, regardless of the provider settings