### PR TITLE
Fix setState race conditions

### DIFF
--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -7,7 +7,7 @@ import Collapse from '@material-ui/core/Collapse';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
 import { getTransitionDirection, getSnackbarClasses, getCollapseClasses } from './SnackbarItem.util';
 import styles from './SnackbarItem.styles';
-import { capitalise, MESSAGES } from '../utils/constants';
+import { capitalise, MESSAGES, REASONS } from '../utils/constants';
 import warning from '../utils/warning';
 
 
@@ -28,12 +28,16 @@ class SnackbarItem extends Component {
         this.props.onClose(event, reason, key);
     };
 
-    handleEntered = key => () => {
+    handleEntered = key => (node, isAppearing) => {
         const { snack } = this.props;
-        if (snack.requestClose)
-            this.props.onClose(null, null, key)
-        else
-            this.props.onEntered(key);
+        if (snack.requestClose) {
+            this.handleClose(key)(null, REASONS.MAXSNACK);
+        } else {
+            if (snack.onEntered) {
+                snack.onEntered(node, isAppearing, key);
+            }
+            this.props.onEntered(node, isAppearing, key);
+        }
     }
 
     handleExited = key => (event) => {

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -34,6 +34,7 @@ class SnackbarItem extends Component {
             snack.onEntered(node, isAppearing, key);
         }
         this.props.onEntered(node, isAppearing, key);
+
         if (snack.requestClose) {
             this.handleClose(key)(null, REASONS.MAXSNACK);
         }
@@ -184,6 +185,7 @@ SnackbarItem.propTypes = {
     dense: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     onExited: PropTypes.func.isRequired,
+    onEntered: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(SnackbarItem);

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -30,13 +30,12 @@ class SnackbarItem extends Component {
 
     handleEntered = key => (node, isAppearing) => {
         const { snack } = this.props;
+        if (snack.onEntered) {
+            snack.onEntered(node, isAppearing, key);
+        }
+        this.props.onEntered(node, isAppearing, key);
         if (snack.requestClose) {
             this.handleClose(key)(null, REASONS.MAXSNACK);
-        } else {
-            if (snack.onEntered) {
-                snack.onEntered(node, isAppearing, key);
-            }
-            this.props.onEntered(node, isAppearing, key);
         }
     }
 

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -28,6 +28,14 @@ class SnackbarItem extends Component {
         this.props.onClose(event, reason, key);
     };
 
+    handleEntered = key => () => {
+        const { snack } = this.props;
+        if (snack.requestClose)
+            this.props.onClose(null, null, key)
+        else
+            this.props.onEntered(key);
+    }
+
     handleExited = key => (event) => {
         const { onExited, snack: { onExited: singleOnExited } } = this.props;
         if (singleOnExited) singleOnExited(event, key);
@@ -65,6 +73,8 @@ class SnackbarItem extends Component {
             action: singleAction,
             ContentProps: singleContentProps = {},
             anchorOrigin,
+            requestClose,
+            entered,
             ...singleSnackProps
         } = snack;
 
@@ -115,6 +125,7 @@ class SnackbarItem extends Component {
                     open={snack.open}
                     classes={getSnackbarClasses(classes)}
                     onClose={this.handleClose(key)}
+                    onEntered={this.handleEntered(key)}
                 >
                     {snackContent || (
                         <SnackbarContent
@@ -156,6 +167,8 @@ SnackbarItem.propTypes = {
             PropTypes.number,
         ]).isRequired,
         open: PropTypes.bool.isRequired,
+        requestClose: PropTypes.bool.isRequired,
+        entered: PropTypes.bool.isRequired,
     }).isRequired,
     iconVariant: PropTypes.shape({
         success: PropTypes.any.isRequired,

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -66,10 +66,10 @@ class SnackbarProvider extends Component {
                     userSpecifiedKey ? item.key === key : item.message === message
                 );
 
-                const inQueue = this.queue.findIndex(compareFunction) > -1;
-                const inView = this.state.snacks.findIndex(compareFunction) > -1;
+                const inQueue = state.queue.findIndex(compareFunction) > -1;
+                const inView = state.snacks.findIndex(compareFunction) > -1;
                 if (inQueue || inView) {
-                    return null;
+                    return state;
                 }
             }
 

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -186,12 +186,17 @@ class SnackbarProvider extends Component {
         }
 
         if (reason === REASONS.CLICKAWAY) return;
+        const shouldRemoveAll = key === undefined;
 
         this.setState(({ snacks, queue }) => ({
             snacks: snacks.map(item => (
-                (!key || item.key === key) ? { ...item, open: false } : { ...item }
+                shouldRemoveAll || item.key === key
+                  ? item.entered
+                    ? { ...item, open: false }
+                    : { ...item, requestClose: true }
+                  : { ...item }
             )),
-            queue: queue.filter(item => item.key !== key),
+            queue: queue.filter(item => item.key !== key), // eslint-disable-line react/no-unused-state
         }));
     };
 

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -23,7 +23,7 @@ class SnackbarProvider extends Component {
         super(props);
         this.state = {
             snacks: [],
-            queue: [],
+            queue: [], // eslint-disable-line react/no-unused-state
             contextValue: {
                 enqueueSnackbar: this.enqueueSnackbar,
                 closeSnackbar: this.closeSnackbar,
@@ -75,7 +75,7 @@ class SnackbarProvider extends Component {
 
             return this.handleDisplaySnack({
                 ...state,
-                queue: [...state.queue, snack]
+                queue: [...state.queue, snack],
             });
         });
 
@@ -83,7 +83,7 @@ class SnackbarProvider extends Component {
     };
 
     /**
-     * Reducer: Display snack if there's space for it. Otherwise, immediately 
+     * Reducer: Display snack if there's space for it. Otherwise, immediately
      * begin dismissing the oldest message to start showing the new one.
      */
     handleDisplaySnack = (state) => {
@@ -104,7 +104,7 @@ class SnackbarProvider extends Component {
                 ...state,
                 snacks: [...snacks, queue[0]],
                 queue: queue.slice(1, queue.length),
-            }
+            };
         }
         return state;
     };
@@ -143,14 +143,15 @@ class SnackbarProvider extends Component {
                         ...item,
                         requestClose: true,
                     };
-                } else {
-                    if (item.onClose) item.onClose(null, REASONS.MAXSNACK, item.key);
-                    if (this.props.onClose) this.props.onClose(null, REASONS.MAXSNACK, item.key);
-                    return {
-                        ...item,
-                        open: false,
-                    };
                 }
+
+                if (item.onClose) item.onClose(null, REASONS.MAXSNACK, item.key);
+                if (this.props.onClose) this.props.onClose(null, REASONS.MAXSNACK, item.key);
+
+                return {
+                    ...item,
+                    open: false,
+                };
             }
 
             return { ...item };
@@ -186,16 +187,18 @@ class SnackbarProvider extends Component {
         }
 
         if (reason === REASONS.CLICKAWAY) return;
-        const shouldRemoveAll = key === undefined;
+        const shouldCloseAll = key === undefined;
 
         this.setState(({ snacks, queue }) => ({
-            snacks: snacks.map(item => (
-                shouldRemoveAll || item.key === key
-                  ? item.entered
+            snacks: snacks.map((item) => {
+                if (!shouldCloseAll && item.key !== key) {
+                    return { ...item };
+                }
+
+                return item.entered
                     ? { ...item, open: false }
-                    : { ...item, requestClose: true }
-                  : { ...item }
-            )),
+                    : { ...item, requestClose: true };
+            }),
             queue: queue.filter(item => item.key !== key), // eslint-disable-line react/no-unused-state
         }));
     };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -81,3 +81,8 @@ export const SNACKBAR_INDENTS = {
 export const capitalise = text => text.charAt(0).toUpperCase() + text.slice(1);
 
 export const originKeyExtractor = anchor => `${capitalise(anchor.vertical)}${capitalise(anchor.horizontal)}`;
+
+export const REASONS = {
+    CLICKAWAY: 'clickaway',
+    MAXSNACK: 'maxsnack',
+};


### PR DESCRIPTION
This pull request fixes #38 and #175. Main rationale of the pull request:
- Using reducer functions to adapt the state to avoid race conditions.
- `handleDismissOldest` no longer removes closed messages, this should only happen in `handleExitedSnack`.
- Introduced `entered` and `requestClose` boolean variables. With these variables, a snackbar should first have fully entered the window before it can be dismissed. This is needed for e.g. the case `maxSnack = 1` and `enqueueSnackbar` called twice. Without the variables, the `open` prop of the first snackbar would immediately be set to `false`, without the snackbar ever being rendered. In this case, the `handleExitedSnack` function would never be called for that snackbar and it would be always in the view (although hidden due to `open = false`).
- Added `queue: queue.filter(item => item.key !== key),` to `handleCloseSnack` for #175.

Old codesandbox (#38): https://codesandbox.io/s/notistack-simple-example-xpff1
Fixed codesandbox: https://codesandbox.io/s/notistack-simple-example-yd6gw 

Note: a possible 'breaking' change is that `enqueueSnackbar` no longer returns null as id if it prevented a duplicate. (This is due to the asynchronous setState.)

Any comments are welcome.