### PR TITLE
Check for item key when a key is provided to prevent duplicates

### DIFF
--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -50,8 +50,12 @@ class SnackbarProvider extends Component {
      */
     enqueueSnackbar = (message, { key, preventDuplicate, ...options } = {}) => {
         if ((preventDuplicate === undefined && this.props.preventDuplicate) || preventDuplicate) {
-            const inQueue = this.queue.findIndex(item => key ? item.key === key : item.message === message) > -1;
-            const inView = this.state.snacks.findIndex(item => key ? item.key === key : item.message === message) > -1;
+            const compareFunction = (item) => (
+                (key || key === 0) ? item.key === key : item.message === message
+            )
+
+            const inQueue = this.queue.findIndex(compareFunction) > -1;
+            const inView = this.state.snacks.findIndex(compareFunction) > -1;
             if (inQueue || inView) {
                 return null;
             }

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -50,8 +50,8 @@ class SnackbarProvider extends Component {
      */
     enqueueSnackbar = (message, { key, preventDuplicate, ...options } = {}) => {
         if (preventDuplicate || this.props.preventDuplicate) {
-            const inQueue = this.queue.findIndex(item => item.message === message) > -1;
-            const inView = this.state.snacks.findIndex(item => item.message === message) > -1;
+            const inQueue = this.queue.findIndex(item => key ? item.key === key : item.message === message) > -1;
+            const inView = this.state.snacks.findIndex(item => key ? item.key === key : item.message === message) > -1;
             if (inQueue || inView) {
                 return null;
             }


### PR DESCRIPTION
Currently if you have two notification with the same `message` text, but a different `key`, only the `message` is used to prevent duplicates.

When a user defined `key` is provided to `enqueueSnackbar` it makes sense to compare the `key` instead of the `message` to prevent duplicates.

This becomes relevant when you pass a `React.Node` as `message`. Or when you want to replace a Snackbar with a new one, where the message is the same but the actions are different.