### PR TITLE
Safe override of TransitionProps

### DIFF
--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -63,6 +63,7 @@ class SnackbarItem extends Component {
             iconVariant,
             snack,
             dense,
+            TransitionProps: otherTransitionProps = {},
             ...other
         } = this.props;
 
@@ -79,6 +80,7 @@ class SnackbarItem extends Component {
             anchorOrigin,
             requestClose,
             entered,
+            TransitionProps: singleTransitionProps = {},
             ...singleSnackProps
         } = snack;
 
@@ -88,6 +90,13 @@ class SnackbarItem extends Component {
             ...otherContentProps,
             ...singleContentProps,
             action: singleAction || singleContentProps.action || contentAction || action,
+        };
+
+        const transitionProps = {
+            ...otherTransitionProps,
+            ...singleTransitionProps,
+            direction: getTransitionDirection(anchorOrigin),
+            onExited: this.handleExitedScreen,
         };
 
         const ariaDescribedby = contentProps['aria-describedby'] || 'client-snackbar';
@@ -119,10 +128,7 @@ class SnackbarItem extends Component {
                 onExited={this.handleExited(key)}
             >
                 <Snackbar
-                    TransitionProps={{
-                        direction: getTransitionDirection(anchorOrigin),
-                        onExited: this.handleExitedScreen,
-                    }}
+                    TransitionProps={transitionProps}
                     {...other}
                     {...singleSnackProps}
                     anchorOrigin={anchorOrigin}

--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -93,9 +93,9 @@ class SnackbarItem extends Component {
         };
 
         const transitionProps = {
+            direction: getTransitionDirection(anchorOrigin),
             ...otherTransitionProps,
             ...singleTransitionProps,
-            direction: getTransitionDirection(anchorOrigin),
             onExited: this.handleExitedScreen,
         };
 
@@ -128,11 +128,11 @@ class SnackbarItem extends Component {
                 onExited={this.handleExited(key)}
             >
                 <Snackbar
-                    TransitionProps={transitionProps}
                     {...other}
                     {...singleSnackProps}
-                    anchorOrigin={anchorOrigin}
                     open={snack.open}
+                    anchorOrigin={anchorOrigin}
+                    TransitionProps={transitionProps}
                     classes={getSnackbarClasses(classes)}
                     onClose={this.handleClose(key)}
                     onEntered={this.handleEntered(key)}


### PR DESCRIPTION
As of now, a user can only override the full TransitionProps (and not extend it), which can lead to bugs because of the `handleExitedScreen` callback not being fired. This PR fixes this bug.

Bug example: https://codesandbox.io/s/notistack-simple-example-wp5bc (Click on default, wait a bit and click on another button. The second snackbar is not rendered because the `handleExitedScreen` callback is not fired and thus the first snackbar is not removed, leaving no place since `maxSnack={1}`.)