### PR TITLE
Add a type for onExited handler with key

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,20 +1,26 @@
 import * as React from 'react';
 import { SnackbarProps, SnackbarClassKey } from '@material-ui/core/Snackbar';
 import { SnackbarContentProps } from '@material-ui/core/SnackbarContent';
+import { ExitHandler } from 'react-transition-group/Transition'
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
 
 export type VariantType = 'default' | 'error' | 'success' | 'warning' | 'info';
 
+export type Key = string | number;
+
+export type KeyedExitHandler = (...event: Parameters<ExitHandler>, key: Key) => void
+
 export interface OptionsObject extends Omit<SnackbarProps, 'open' | 'message' | 'classes'> {
-    key?: string | number;
+    key?: Key;
     variant?: VariantType;
     persist?: boolean;
     preventDuplicate?: boolean;
     children?: React.ReactNode | ((key: OptionsObject['key']) => React.ReactNode);
     content?: React.ReactNode | ((key: OptionsObject['key']) => React.ReactNode);
     action?: SnackbarContentProps['action'] | ((key: OptionsObject['key']) => React.ReactNode);
+    onExited?: KeyedExitHandler;
 }
 
 export type ContainerClassKey =


### PR DESCRIPTION
Previously the type of onExited was inherited from SnackbarProps, but in the
code this function is called with an extra arg and not actually passed into the
snackbar props.