### PR TITLE
Prevent useSnackbar from returning a new object on every call

### DIFF
--- a/src/useSnackbar.js
+++ b/src/useSnackbar.js
@@ -2,10 +2,5 @@ import { useContext } from 'react';
 import SnackbarContext from './SnackbarContext';
 
 export default () => {
-    const { enqueueSnackbar, closeSnackbar } = useContext(SnackbarContext);
-
-    return {
-        enqueueSnackbar,
-        closeSnackbar,
-    };
+    return useContext(SnackbarContext);
 };


### PR DESCRIPTION
At the moment, `useSnackbar` will return a new object on every call.

This causes a problem when using it in an effect and specifying it as a dependency (exhaustive-deps check will fail otherwise), as it will cause the effect to run every time the component renders, since React sees the snackbar object as changed.

By returning the context directly, the object should never change.