### PR TITLE
Add  `base` to `CombinedClassKey`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,8 +45,9 @@ export type ContainerClassKey =
     | 'containerAnchorOriginTopLeft'
     | 'containerAnchorOriginBottomLeft';
 
+export type RootClassKey = 'base'
 export type VariantClassKey = 'variantSuccess' | 'variantError' | 'variantInfo' | 'variantWarning';
-export type CombinedClassKey = VariantClassKey | ContainerClassKey | SnackbarClassKey;
+export type CombinedClassKey = RootClassKey | VariantClassKey | ContainerClassKey | SnackbarClassKey;
 
 export interface WithSnackbarProps {
     enqueueSnackbar: (message: SnackbarMessage, options?: OptionsObject) => SnackbarKey;


### PR DESCRIPTION
to clearly indicate that you can use `base` to customize `SnackBarItem`.

I want to apply css to not only limited variants, but all type of component.
Practically, you can use `base` but not written on *index.d.ts*

```console
Material-UI: the key `foobar` provided to the classes prop is not implemented in SnackbarItem.
You can only override one of the following: root,anchorOriginTopCenter,anchorOriginBottomCenter,anchorOriginTopRight,anchorOriginBottomRight,anchorOriginTopLeft,anchorOriginBottomLeft,base,lessPadding,variantSuccess,variantError,variantInfo,variantWarning,message,wrappedRoot,collapseContainer,collapseWrapper,collapseWrapperDense.
```