### PR TITLE
🔧 fix icon end margin for RTL language

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -58,7 +58,7 @@ export const allClasses = {
 const iconStyles = {
     opacity: 0.9,
     fontSize: 20,
-    marginRight: 8,
+    marginInlineEnd: 8,
 };
 
 export const defaultIconVariant = {


### PR DESCRIPTION
Hi,
I changed `marginRight` of icon to `marginInlineEnd` for working good with RTL languages like Persian.
- before:
![image](https://user-images.githubusercontent.com/29185622/76578628-76fc8780-64de-11ea-8afc-c3bb3a70bf8e.png)
- after
![image](https://user-images.githubusercontent.com/29185622/76578647-84197680-64de-11ea-9f00-273e0c26db34.png)

Thanks!