### PR TITLE
Fix content color for dark theme

### DIFF
--- a/src/SnackbarItem/SnackbarItem.styles.js
+++ b/src/SnackbarItem/SnackbarItem.styles.js
@@ -1,3 +1,5 @@
+import { green, red, blue, amber } from '@material-ui/core/colors';
+
 import { SNACKBAR_INDENTS, allClasses } from '../utils/constants';
 
 const styles = theme => ({
@@ -13,16 +15,20 @@ const styles = theme => ({
         paddingLeft: 8 * 2.5,
     },
     variantSuccess: {
-        backgroundColor: '#43a047', // green
+        backgroundColor: green[600], // green
+        color: '#fff',
     },
     variantError: {
-        backgroundColor: '#d32f2f', // dark red
+        backgroundColor: red[700], // dark red
+        color: '#fff',
     },
     variantInfo: {
-        backgroundColor: '#2979ff', // nice blue
+        backgroundColor: blue.A400, // nice blue
+        color: '#fff',
     },
     variantWarning: {
-        backgroundColor: '#ffa000', // amber
+        backgroundColor: amber[700], // amber
+        color: rgba(0, 0, 0, 0.87),
     },
     message: {
         display: 'flex',


### PR DESCRIPTION
fix the content color when using a dark theme

> Before:
> ![image](https://user-images.githubusercontent.com/54638376/77268250-e68d2680-6cd7-11ea-8622-ccd1dd596991.png)

> After
> ![image](https://user-images.githubusercontent.com/54638376/77268963-30770c00-6cda-11ea-8324-1f9b79d9215b.png)
