### PR TITLE
Pass options down to snackContent

### DIFF
--- a/src/SnackbarItem/SnackbarItem.js
+++ b/src/SnackbarItem/SnackbarItem.js
@@ -121,7 +121,7 @@ class SnackbarItem extends Component {
 
         let snackContent = singleContent || content;
         if (snackContent && typeof snackContent === 'function') {
-            snackContent = snackContent(key, snack.message);
+            snackContent = snackContent(key, snack.message, {variant, ...singleSnackProps});
         }
 
         return (


### PR DESCRIPTION
This is a PR for issue: #242

It should be possible for custom snackbars to receive the items inside the options object passed into `enqueueSnack()`