### PR TITLE
Pass snackbar options down to content callback

### DIFF
--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -192,7 +192,7 @@ const SnackbarItem: React.FC<SnackbarItemProps> = ({ classes, ...props }) => {
 
     let snackContent = singleContent || content;
     if (snackContent && typeof snackContent === 'function') {
-        snackContent = snackContent(key, snack.message);
+        snackContent = snackContent(key, snack.message, contentProps);
     }
 
     return (

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,10 +17,10 @@ type Modify<T, R> = Pick<T, Exclude<keyof T, keyof R>> & R
 export type SnackbarKey = string | number;
 export type VariantType = 'default' | 'error' | 'success' | 'warning' | 'info';
 export type CloseReason = 'timeout' | 'clickaway' | 'maxsnack' | 'instructed';
-
+export type CustomContentProps = {[prop:string]: any};
 export type SnackbarMessage = string | React.ReactNode;
 export type SnackbarAction = React.ReactNode | ((key: SnackbarKey) => React.ReactNode);
-export type SnackbarContent = React.ReactNode | ((key: SnackbarKey, message: SnackbarMessage) => React.ReactNode);
+export type SnackbarContent = React.ReactNode | ((key: SnackbarKey, message: SnackbarMessage, ContentProps?: Partial<SnackbarContentProps> | CustomContentProps ) => React.ReactNode);
 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #242 

Can pass custom props to 'content'.

Usage:

```
<SnackbarProvider content={(key, message, other) => (
    <CustomContent id={key} message={message} {...other} />
)}>
   <App /></SnackbarProvider>
```

Inside App component:
```
this.props.enqueueSnackbar( message, {
       ContentProps: {
            myCustomProp:123 
       }
});
```


Inside CustomContent component
```
const CustomContent= (props) => {
    const classes = useStyles();
    const { closeSnackbar } = useSnackbar();
    const [expanded, setExpanded] = useState(false);
    if(props.myCustomProp){
        // Do something with new prop!
        console.log(props.myCustomProp);
    }
.....
```

Note that ContentProp has some reserved properties from https://material-ui.com/api/snackbar/
The properties are : classes, role, message, action.
**Using these property names in the ContentProp object, will override what is passed to the content.**