### PR TITLE
Update shared props interface to allow data-* attributes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -214,6 +214,10 @@ export interface OptionsObject extends SharedProps {
      * @default false
      */
     persist?: boolean;
+    /**
+     * Allow html data-* attributes. Will be passed down to the MuiSnackbar-root
+     */
+    [key?: string]: string;
 }
 
 /**


### PR DESCRIPTION
Regarding https://github.com/iamhosseindhv/notistack/issues/101 you mentioned that it is allowed to pass custom data attributes to `enqueueSnackbar`. Currently this is not possible because of the ts interface.

I added `[key?: string]: string;` to the interface to allow new attributes. Not sure if this is the correct way. I am open for a discussion :) 

Cheers,
Achim ✌️  