### PR TITLE
Let MUI handle the font and border-radius

### DIFF
--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -13,13 +13,6 @@ import { Snack } from '../SnackbarProvider';
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = (theme: Theme) => createStyles({
     ...allClasses.mui,
-    base: {
-        fontSize: '0.875rem',
-        lineHeight: '1.46429em',
-        fontWeight: theme.typography.fontWeightRegular,
-        fontFamily: theme.typography.fontFamily,
-        borderRadius: theme.shape.borderRadius,
-    },
     lessPadding: {
         paddingLeft: 8 * 2.5,
     },
@@ -218,7 +211,6 @@ const SnackbarItem: React.FC<SnackbarItemProps> = ({ classes, ...props }) => {
                 {snackContent || (
                     <SnackbarContent
                         className={clsx(
-                            classes.base,
                             classes[`variant${capitalise(variant)}` as VariantClassKey],
                             { [classes.lessPadding]: !hideIconVariant && icon },
                             className,


### PR DESCRIPTION
MUI calculates the rem size based on the HTML font size so hard coding the font size goes against their calculations and looks odd when HTML is e.g. 11px

https://material-ui.com/customization/typography/#html-font-size

![image](https://user-images.githubusercontent.com/5055248/81170718-0f6d3080-8f93-11ea-97a1-a2eb06b13083.png)
