### PR TITLE
Allow for "variantDefault" in classes

### DIFF
--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -17,6 +17,10 @@ const styles = (theme: Theme) => createStyles({
     lessPadding: {
         paddingLeft: 8 * 2.5,
     },
+    variantDefault: {
+        backgroundColor: '#313131', // light black
+        color: '#fff',
+    },
     variantSuccess: {
         backgroundColor: '#43a047', // green
         color: '#fff',


### PR DESCRIPTION
We would like to be able to customize the "default" variant, which is possible using `classes.variantDefault` .

But doing so we get a lot of errors in the browser's console.