### PR TITLE
fix support for new version of @material-ui/core

### DIFF
--- a/src/SnackbarProvider.tsx
+++ b/src/SnackbarProvider.tsx
@@ -173,6 +173,9 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
      * Set the entered state of the snackbar with the given key.
      */
     handleEnteredSnack: TransitionHandlerProps['onEntered'] = (node, isAppearing, key) => {
+        // newer versions of @material-ui/core won't pass isAppearing argument for handleEntered
+        key = key === undefined ? ((isAppearing as unknown) as SnackbarKey) : key;
+
         if (!key) {
             throw new Error('handleEnteredSnack Cannot be called with undefined key');
         }


### PR DESCRIPTION
Hi, 

I noticed a bug in my `jest` tests with your library (testing using `react/testing-library`), it seems that the `@material-ui/core` library in one of the previous versions stopped pasing `isAppearing` for certain callbacks which caused this to be thrown:  "handleEnteredSnack Cannot be called with undefined key".


I'm not sure why I only experienced this in my tests, but I believe this is the change that affects your lib: https://github.com/mui-org/material-ui/commit/3443d2ce16f3280318a163a45faff8ba86f45903

With this PR the library should support `@material-ui/core` both before and after the change was made.
