### PR TITLE
Replaceable snackbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Thanks to all contributers who improved notistack by opening an issue/PR.
 ###### to be published
 * **@pctestjfarz**: Add swipe to dismiss feature [#138](https://github.com/iamhosseindhv/notistack/issues/138) 
 * **@molynerd**: Add support to update content of snackbar in place [#50](https://github.com/iamhosseindhv/notistack/issues/50)
-* **@primal100**: A new snackbars now replaces any previous snackbar with the same key if preventDuplicate is not enabled
+* **@primal100**: A new snackbar now replaces any previous snackbar with the same key if preventDuplicate is not enabled
 
 <br />
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Thanks to all contributers who improved notistack by opening an issue/PR.
 ###### to be published
 * **@pctestjfarz**: Add swipe to dismiss feature [#138](https://github.com/iamhosseindhv/notistack/issues/138) 
 * **@molynerd**: Add support to update content of snackbar in place [#50](https://github.com/iamhosseindhv/notistack/issues/50)
-
+* **@primal100**: A new snackbars now replaces any previous snackbar with the same key if preventDuplicate is not enabled
 
 <br />
 


### PR DESCRIPTION
A new snackbar now replaces any previous snackbar with the same key if preventDuplicate is not enabled

This is particularly useful for showing the status of tasks (e.g. file uploads) and makes it more compliant with React documentation as two snackbars with the same key should not be allowed.

This was first suggested in #256 back in April.