### PR TITLE
IE11 Message width with Flexbox message

### DIFF
--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -48,7 +48,7 @@ const styles = (theme: Theme) => {
             display: 'flex',
             alignItems: 'center',
             padding: '8px 0',
-	    flex: 1,
+	        flex: 1,
         },
         action: {
             display: 'flex',

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -48,7 +48,7 @@ const styles = (theme: Theme) => {
             display: 'flex',
             alignItems: 'center',
             padding: '8px 0',
-	        flex: 1,
+            flex: 1,
         },
         action: {
             display: 'flex',

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -48,6 +48,7 @@ const styles = (theme: Theme) => {
             display: 'flex',
             alignItems: 'center',
             padding: '8px 0',
+	    flex: 1,
         },
         action: {
             display: 'flex',


### PR DESCRIPTION
In IE11, if you want to use a Flexbox component as a message it won't be able to display it properly because the parent width will be the same as the icon it self, so with every white-space the message will break into a multiple lines, this is because in IE11 the flex box won't be fill the remaining horizontal space in Flexbox.