### PR TITLE
Update peer dependencies for react 17.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
     },
     "peerDependencies": {
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
         "@material-ui/core": "^4.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Otherwise we get this error when running `npm install` using React 17.x:

```
npm ERR! Found: react@17.0.1
npm ERR! node_modules/react
npm ERR!   react@"^17.0.1" from the root project
npm ERR!   peer react@"^16.8.0 || ^17.0.0" from @material-ui/core@4.11.2
npm ERR!   node_modules/@material-ui/core
npm ERR!     @material-ui/core@"^4.11.2" from the root project
npm ERR!     peer @material-ui/core@"^4.0.0" from notistack@1.0.2
npm ERR!     node_modules/notistack
npm ERR!       notistack@"^1.0.2" from the root project
npm ERR!   1 more (react-dom)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.0" from notistack@1.0.2
npm ERR! node_modules/notistack
npm ERR!   notistack@"^1.0.2" from the root project
```