### PR TITLE
Add stylesheet name

### DIFF
--- a/src/SnackbarContainer.tsx
+++ b/src/SnackbarContainer.tsx
@@ -44,7 +44,7 @@ const useStyle = makeStyles(theme => ({
             transform: 'translateX(0)',
         },
     },
-}));
+}), { name: 'notistack' });
 
 
 interface SnackbarContainerProps {


### PR DESCRIPTION
The name helps to distinguish notistack's stylesheet among others, particularly when debugging web page performance. The name is shown in a data attribute of the <style> tag instead of "makeStyles". On a large Material-UI project, if multiple stylesheets have no names and show "makeStyles" instead, it makes performance optimization and stylesheet debugging work much much harder.