### PR TITLE
Add note of peerdeps in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Table of Contents
 
 
 ## Getting Started
+Note that this package requires `@material-ui/core` **v4**. 
 Use your preferred package manager:
 ```
 npm install notistack


### PR DESCRIPTION
At the moment this library requires material ui. I see many people have the same problem (thinking it doesn't). This change makes it clear