### PR TITLE
Fix support for next version of @material-ui/core

### DIFF
--- a/examples/simple-example/MessageButtons.js
+++ b/examples/simple-example/MessageButtons.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import clsx from 'clsx';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 import { withSnackbar } from 'notistack';

--- a/src/SnackbarContainer.tsx
+++ b/src/SnackbarContainer.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
+import { Theme } from '@material-ui/core/styles';
 import { SNACKBAR_INDENTS } from './utils/constants';
 import { SnackbarProviderProps } from '.';
+import createTheme from '../utils/createTheme';
 
 const collapse = {
     container: '& > .MuiCollapse-container',
@@ -10,8 +12,9 @@ const collapse = {
 };
 
 const xsWidthMargin = 16;
+const defaultTheme = createTheme();
 
-const useStyle = makeStyles((theme) => ({
+const useStyle = makeStyles((theme: Theme) => ({
     root: {
         boxSizing: 'border-box',
         display: 'flex',
@@ -74,7 +77,7 @@ const useStyle = makeStyles((theme) => ({
             alignItems: 'center',
         },
     },
-}));
+}), { defaultTheme });
 
 
 interface SnackbarContainerProps {

--- a/src/SnackbarContainer.tsx
+++ b/src/SnackbarContainer.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import clsx from 'clsx';
 import { makeStyles } from '@material-ui/styles';
-import { Theme } from '@material-ui/core/styles';
+import { Theme, createMuiTheme as createTheme } from '@material-ui/core/styles';
 import { SNACKBAR_INDENTS } from './utils/constants';
 import { SnackbarProviderProps } from '.';
-import createTheme from './utils/createTheme';
 
 const collapse = {
     container: '& > .MuiCollapse-container',

--- a/src/SnackbarContainer.tsx
+++ b/src/SnackbarContainer.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/styles';
 import { Theme } from '@material-ui/core/styles';
 import { SNACKBAR_INDENTS } from './utils/constants';
 import { SnackbarProviderProps } from '.';
-import createTheme from '../utils/createTheme';
+import createTheme from './utils/createTheme';
 
 const collapse = {
     container: '& > .MuiCollapse-container',

--- a/src/SnackbarContent/SnackbarContent.tsx
+++ b/src/SnackbarContent/SnackbarContent.tsx
@@ -1,9 +1,8 @@
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import { withStyles, WithStyles, createStyles } from '@material-ui/styles'
-import { Theme } from '@material-ui/core/styles';
+import { Theme, createMuiTheme as createTheme } from '@material-ui/core/styles';
 import { SnackbarContentProps } from '../index';
-import createTheme from '../utils/createTheme';
 
 const styles = (theme: Theme) => createStyles({
     root: {

--- a/src/SnackbarContent/SnackbarContent.tsx
+++ b/src/SnackbarContent/SnackbarContent.tsx
@@ -1,7 +1,9 @@
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { withStyles, WithStyles, createStyles } from '@material-ui/styles'
+import { Theme } from '@material-ui/core/styles';
 import { SnackbarContentProps } from '../index';
+import createTheme from '../utils/createTheme';
 
 const styles = (theme: Theme) => createStyles({
     root: {
@@ -21,4 +23,5 @@ const SnackbarContent = forwardRef<HTMLDivElement, Props>(({ classes, className,
     <div ref={ref} className={clsx(classes.root, className)}  {...props} />
 ))
 
-export default withStyles(styles)(SnackbarContent);
+const defaultTheme = createTheme();
+export default withStyles(styles, { defaultTheme })(SnackbarContent);

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { withStyles, WithStyles, createStyles } from '@material-ui/styles';
-import { Theme, emphasize } from '@material-ui/core/styles';
-import createTheme from '../utils/createTheme';
+import { Theme, emphasize, createMuiTheme as createTheme } from '@material-ui/core/styles';
 import Collapse from '@material-ui/core/Collapse';
 import SnackbarContent from '../SnackbarContent';
 import { getTransitionDirection } from './SnackbarItem.util';

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -253,5 +253,5 @@ const SnackbarItem: React.FC<SnackbarItemProps> = ({ classes, ...props }) => {
     );
 };
 
-const defaultTheme = createMuiTheme();
+const defaultTheme = createTheme();
 export default withStyles(styles, { defaultTheme })(SnackbarItem);

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import clsx from 'clsx';
-import { withStyles, WithStyles, createStyles, Theme, emphasize } from '@material-ui/core/styles';
+import { withStyles, WithStyles, createStyles } from '@material-ui/styles';
+import { createMuiTheme, Theme, emphasize } from '@material-ui/core/styles';
 import Collapse from '@material-ui/core/Collapse';
 import SnackbarContent from '../SnackbarContent';
 import { getTransitionDirection } from './SnackbarItem.util';
@@ -251,4 +252,5 @@ const SnackbarItem: React.FC<SnackbarItemProps> = ({ classes, ...props }) => {
     );
 };
 
-export default withStyles(styles)(SnackbarItem);
+const defaultTheme = createMuiTheme();
+export default withStyles(styles, { defaultTheme })(SnackbarItem);

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { withStyles, WithStyles, createStyles } from '@material-ui/styles';
-import { createMuiTheme, Theme, emphasize } from '@material-ui/core/styles';
+import { Theme, emphasize } from '@material-ui/core/styles';
+import createTheme from '../utils/createTheme';
 import Collapse from '@material-ui/core/Collapse';
 import SnackbarContent from '../SnackbarContent';
 import { getTransitionDirection } from './SnackbarItem.util';

--- a/src/utils/createTheme.js
+++ b/src/utils/createTheme.js
@@ -1,0 +1,5 @@
+import * as styles from '@material-ui/core/styles';
+
+export default function createTheme(newTheme) {
+  return styles.createMuiTheme ? styles.createMuiTheme(newTheme) : styles.createTheme(newTheme);
+}

--- a/src/utils/createTheme.js
+++ b/src/utils/createTheme.js
@@ -1,5 +1,0 @@
-import * as styles from '@material-ui/core/styles';
-
-export default function createTheme(newTheme) {
-  return styles.createMuiTheme ? styles.createMuiTheme(newTheme) : styles.createTheme(newTheme);
-}


### PR DESCRIPTION
Changes done:
- replaces `makeStyles`, `withStyles`, `createStyles` from `@material-ui/core/styles` with ones from `@material-ui/styles`. `defaultTheme` is required to be passed in order to preserve previous behavior.
- ~created `createTheme` util that maps to the legacy `createMuiTheme` or the new `createTheme`~ - reverted these changes see https://github.com/iamhosseindhv/notistack/pull/387#issuecomment-854790479

Not sure how to test the changes locally, any help is appreciated.

Related to https://github.com/mui-org/material-ui/pull/26382