### PR TITLE
Support Collapse with root and container class keys

### DIFF
--- a/src/SnackbarContainer.tsx
+++ b/src/SnackbarContainer.tsx
@@ -5,8 +5,10 @@ import { SNACKBAR_INDENTS } from './utils/constants';
 import { SnackbarProviderProps } from '.';
 
 const collapse = {
-    container: '& > .MuiCollapse-container',
-    wrapper: '& > .MuiCollapse-container > .MuiCollapse-wrapper',
+    // Material-UI 4.12.x and above uses MuiCollapse-root; earlier versions use
+    // Mui-Collapse-container.  https://github.com/mui-org/material-ui/pull/24084
+    container: '& > .MuiCollapse-container, & > .MuiCollapse-root',
+    wrapper: '& > .MuiCollapse-container > .MuiCollapse-wrapper, & > .MuiCollapse-root > .MuiCollapse-wrapper',
 };
 
 const xsWidthMargin = 16;


### PR DESCRIPTION
As an alternative to #396, if you decide that you want a more limited-in-scope code change that should work in both in Material-UI 4.12.x and in older version of Material-UI, here's a fix that just updates the CSS selectors.

Fixes #394.