### PR TITLE
Fix 427

### DIFF
--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -28,7 +28,6 @@ const classes = {
 
 const StyledSnackbar = styled(Snackbar)(({ theme }) => {
     const mode = theme.palette.mode;
-    const backgroundColor = emphasize(theme.palette.background.default, mode === 'light' ? 0.8 : 0.98);
 
     return {
         [`&.${classes.wrappedRoot}`]: {
@@ -41,8 +40,8 @@ const StyledSnackbar = styled(Snackbar)(({ theme }) => {
         },
         [`.${classes.contentRoot}`]: {
             ...theme.typography.body2,
-            backgroundColor,
-            color: theme.palette.getContrastText(backgroundColor),
+            backgroundColor: emphasize(theme.palette.background.default, mode === 'light' ? 0.8 : 0.98),
+            color: theme.palette.getContrastText(emphasize(theme.palette.background.default, mode === 'light' ? 0.8 : 0.98)),
             alignItems: 'center',
             padding: '6px 16px',
             borderRadius: '4px',

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -27,7 +27,7 @@ const classes = {
 };
 
 const StyledSnackbar = styled(Snackbar)(({ theme }) => {
-    const mode = theme.palette.mode || theme.palette.type;
+    const mode = theme.palette.mode;
     const backgroundColor = emphasize(theme.palette.background.default, mode === 'light' ? 0.8 : 0.98);
 
     return {
@@ -52,20 +52,20 @@ const StyledSnackbar = styled(Snackbar)(({ theme }) => {
             paddingLeft: 8 * 2.5,
         },
         [`.${classes.variantSuccess}`]: {
-            backgroundColor: '#43a047', // green
-            color: '#fff',
+            backgroundColor: mode === "light" ? theme.palette.success.main : theme.palette.success.dark,
+            color:  mode === "light" ? theme.palette.getContrastText(theme.palette.success.main) : theme.palette.getContrastText(theme.palette.success.dark),
         },
         [`.${classes.variantError}`]: {
-            backgroundColor: '#d32f2f', // dark red
-            color: '#fff',
+            backgroundColor: mode === "light" ? theme.palette.error.main : theme.palette.error.dark,
+            color:  mode === "light" ? theme.palette.getContrastText(theme.palette.error.main) : theme.palette.getContrastText(theme.palette.error.dark),
         },
         [`.${classes.variantInfo}`]: {
-            backgroundColor: '#2196f3', // nice blue
-            color: '#fff',
+            backgroundColor: mode === "light" ? theme.palette.info.main : theme.palette.info.dark,
+            color:  mode === "light" ? theme.palette.getContrastText(theme.palette.info.main) : theme.palette.getContrastText(theme.palette.info.dark),
         },
         [`.${classes.variantWarning}`]: {
-            backgroundColor: '#ff9800', // amber
-            color: '#fff',
+            backgroundColor: mode === "light" ? theme.palette.warning.main : theme.palette.warning.dark,
+            color:  mode === "light" ? theme.palette.getContrastText(theme.palette.warning.main) : theme.palette.getContrastText(theme.palette.warning.dark),
         },
         [`.${classes.message}`]: {
             display: 'flex',

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -43,12 +43,12 @@ const StyledSnackbar = styled(Snackbar)(({ theme }) => {
             backgroundColor: emphasize(theme.palette.background.default, mode === 'light' ? 0.8 : 0.98),
             color: theme.palette.getContrastText(emphasize(theme.palette.background.default, mode === 'light' ? 0.8 : 0.98)),
             alignItems: 'center',
-            padding: '6px 16px',
+            padding: `${theme.spacing(0.75)} ${theme.spacing(2)}`,
             borderRadius: '4px',
             boxShadow: '0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)',
         },
         [`.${classes.lessPadding}`]: {
-            paddingLeft: 8 * 2.5,
+            paddingLeft: theme.spacing(2.5),
         },
         [`.${classes.variantSuccess}`]: {
             backgroundColor: mode === "light" ? theme.palette.success.main : theme.palette.success.dark,
@@ -69,14 +69,14 @@ const StyledSnackbar = styled(Snackbar)(({ theme }) => {
         [`.${classes.message}`]: {
             display: 'flex',
             alignItems: 'center',
-            padding: '8px 0',
+            padding: `${theme.spacing(1)} 0`,
         },
         [`.${classes.action}`]: {
             display: 'flex',
             alignItems: 'center',
             marginLeft: 'auto',
-            paddingLeft: 16,
-            marginRight: -8,
+            paddingLeft: theme.spacing(2),
+            marginRight: theme.spacing(-1),
         },
     };
 });


### PR DESCRIPTION
This PR is aimed to address ticket #427 by implementing a better integration with the `Material UI theme`.

Question to @iamhosseindhv, do you prefer using the `main` or `light` theme variant for `normal/light` theme. I went with `main` as IMHO it is bright enough for a `light` theme and provides a sufficient contrast ratio.

I also replaced the hardcoded `padding` values with `theme.spacing(n)` so that global changes to a `theme` are directly reflected in the `snackbar`.

Note: This PR is based off the `next` branch for support with `MUI v5`.