### PR TITLE
Ensure variant classes are passed to SnackbarContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Thanks to all contributers who improved notistack by opening an issue/PR.
 
+### `notistack@2.0.3`
+###### Oct 31, 2021
+* **@h0tw4t3r** Ensure `variant` classes are passed to SnackbarContent  [#451](https://github.com/iamhosseindhv/notistack/pull/451) 
+
+<br />
+
 ### `notistack@2.0.2`
 ###### Sep 26, 2021
 * **@hugofpsilva** **@ramosbugs** **@joemaffei** Publish material-ui v5 compatible version as `latest` instead of `next` [#437](https://github.com/iamhosseindhv/notistack/pull/437) 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "notistack",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "notistack",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Highly customizable notification snackbars (toasts) that can be stacked on top of each other",
     "main": "dist/index.js",
     "module": "dist/notistack.esm.js",

--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -246,6 +246,7 @@ const SnackbarItem: React.FC<SnackbarItemProps> = ({ classes: propClasses, ...pr
                                 classes.contentRoot,
                                 { [classes.lessPadding]: !hideIconVariant && icon },
                                 classes[transformer.toVariant(variant)],
+                                propClasses[transformer.toVariant(variant)],
                                 otherClassName,
                                 singleClassName,
                             )}


### PR DESCRIPTION
Fixes #440 

You have to following options to override styles based on variants:

#### Option 1 - styled
```jsx
import { styled } from "@mui/material";
import { SnackbarProvider } from "notistack";

const StyledSnackbarProvider = styled(SnackbarProvider)`
  &.SnackbarItem-variantSuccess {
    background: orange;
  }
`;

export default () => {
  return (
    <StyledSnackbarProvider>
      <MyApp />
    </StyledSnackbarProvider>
  );
};
```

#### Option 2 - makeStyles
```jsx
import { SnackbarProvider } from 'notistack';
import { makeStyles } from "@mui/styles";

const useStyles = makeStyles({
  overriddenError: {
    backgroundColor: "blue !important", // <-- note !important
  }
});


export default () => {
  const classes = useStyles();
  return (
    <SnackbarProvider
        classes={{
            variantError: classes.overriddenError,
        }}
    >
      <MyApp />
    </SnackbarProvider>
  );
};

```


#### Option 3 - notistack v3 (alpha)

Use notistack v3 using `npm i notistack@alpha` (in alpha) which gives you full control over your snackbars. Instead of trying to override styles, you make your own. Here's an example: https://codesandbox.io/s/pedantic-shaw-y3nis
Take a look at `ThemeResponsiveSnackbar.tsx`. Change the styles as you wish.

On v3 you can also define custom variants:

```tsx
<SnackbarProvider
    Components={{
        success: MyCustomSuccessNotification,
        reportComplete: ReportComplete,
    }}
>
</SnackbarProvider>

interface ReportCompleteProps extends CustomContentProps {
    allowDownload: boolean;
}

const ReportComplete = React.forwardRef((props: ReportCompleteProps, ref) => {
    const {
        // You have access to notistack props, options 👇🏼
        variant,
        message
        // as well as your own custom props 👇🏼
        allowDownload,
    } = props;

    // 
})

enqueueSnackbar('Your report is ready to download', {
   variant: 'reportComplete',
   persist: true,
   allowDownload: true, // <-- pass any additional options
})
```

