### PR TITLE
fix: change stack.message to {...stack} for having all options passed…

### DIFF
--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -191,7 +191,7 @@ const SnackbarItem: React.FC<SnackbarItemProps> = ({ classes: propClasses, ...pr
 
     let content = singleContent || otherContent;
     if (typeof content === 'function') {
-        content = content(key, snack.message);
+        content = content(key, {...snack});
     }
 
     // eslint-disable-next-line operator-linebreak


### PR DESCRIPTION
in ```SnackbarProvider``` we have ```content``` props which we can pass our component for customization.
the ```content``` props have two parameters ```key``` and ```message``` but there is only one issue with this, we never actually can find out which variant we showing. 
what i do is just pass the ```snack``` itself so we can have access to all the options we passed to ```enqueueSnackbar``` when we call it.