### PR TITLE
Adds variant to content callback

### DIFF
--- a/src/SnackbarItem/SnackbarItem.tsx
+++ b/src/SnackbarItem/SnackbarItem.tsx
@@ -191,7 +191,7 @@ const SnackbarItem: React.FC<SnackbarItemProps> = ({ classes: propClasses, ...pr
 
     let content = singleContent || otherContent;
     if (typeof content === 'function') {
-        content = content(key, snack.message);
+        content = content(key, snack.message, variant);
     }
 
     // eslint-disable-next-line operator-linebreak

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,7 +18,7 @@ export type CloseReason = 'timeout' | 'clickaway' | 'maxsnack' | 'instructed';
 
 export type SnackbarMessage = string | React.ReactNode;
 export type SnackbarAction = React.ReactNode | ((key: SnackbarKey) => React.ReactNode);
-export type SnackbarContentCallback = React.ReactNode | ((key: SnackbarKey, message: SnackbarMessage) => React.ReactNode);
+export type SnackbarContentCallback = React.ReactNode | ((key: SnackbarKey, message: SnackbarMessage, variant: VariantType) => React.ReactNode);
 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
It would be nice if the content callback could also receive the variant, this way the consumer can better control the type of Content they wish to display in the UI. For example, I could supply an `[Alert](https://mui.com/components/alert/)` component with the proper `variant` property as the Content element. 


```typescript
<SnackbarProvider
    anchorOrigin={{
        vertical: 'bottom',
        horizontal: 'right',
    }}
    content={(key, message, variant) => (
        <Alert id={key} message={message}  severity={variant} />
    )}
>
    <App />
</SnackbarProvider>
```