### PR TITLE
Fix type error with @types/react@17.0.41

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -216,7 +216,7 @@ export interface OptionsObject extends SharedProps {
  * All material-ui props, including class keys for notistack and material-ui with additional notistack props
  * @category Provider
  */
-export interface SnackbarProviderProps extends SharedProps {
+export interface SnackbarProviderProps extends Omit<SharedProps, 'ref'> {
     /**
      * Most of the time this is your App. every component from this point onward
      * will be able to show snackbars.
@@ -249,11 +249,6 @@ export interface SnackbarProviderProps extends SharedProps {
      * Little icon that is displayed at left corner of a snackbar.
      */
     iconVariant?: Partial<IconVariant>;
-    /**
-     * @ignore
-     * SnackbarProvider's ref
-     */
-    ref?: React.Ref<SnackbarProvider>;
 }
 
 export class SnackbarProvider extends React.Component<SnackbarProviderProps> {


### PR DESCRIPTION
When using `notistack` with `@types/react@17.0.41` (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) and `skipLibCheck` set to `false`, it produces this error:

```
ERROR in ../../.yarn/__virtual__/notistack-virtual-0c870af3fa/0/cache/notistack-npm-1.0.10-d186e6ed24-50223dbb30.zip/node_modules/notistack/dist/index.d.ts 219:18-39
TS2430: Interface 'SnackbarProviderProps' incorrectly extends interface 'SharedProps'.
  Types of property 'ref' are incompatible.
    Type 'Ref<SnackbarProvider> | undefined' is not assignable to type 'Ref<unknown> | undefined'.
      Type 'RefCallback<SnackbarProvider>' is not assignable to type 'Ref<unknown> | undefined'.
        Type 'RefCallback<SnackbarProvider>' is not assignable to type 'RefCallback<unknown>'.
          Type 'unknown' is not assignable to type 'SnackbarProvider'.
    217 |  * @category Provider
    218 |  */
  > 219 | export interface SnackbarProviderProps extends SharedProps {
        |                  ^^^^^^^^^^^^^^^^^^^^^
    220 |     /**
    221 |      * Most of the time this is your App. every component from this point onward
    222 |      * will be able to show snackbars.
```

This PR fixes that error by omitting the `ref` prop that it's receiving from `SharedProps`. I also removed the `ref` from `SnackbarProviderProps` since the `ref` attribute is already included automatically by extending `React.Component`.