### PR TITLE
feature/fix: add support onBlur and onFocus

### DIFF
--- a/src/SnackbarItem/Snackbar.js
+++ b/src/SnackbarItem/Snackbar.js
@@ -15,12 +15,15 @@ const Snackbar = React.forwardRef((props, ref) => {
         onClose,
         onMouseEnter,
         onMouseLeave,
+        onFocus,
+        onBlur,
         open,
         resumeHideDuration,
         ...other
     } = props;
 
     const timerAutoHide = React.useRef();
+    const isFocused = React.useRef(false);
 
     const handleClose = useEventCallback((...args) => {
         if (onClose) {
@@ -78,8 +81,27 @@ const Snackbar = React.forwardRef((props, ref) => {
         if (onMouseLeave) {
             onMouseLeave(event);
         }
-        handleResume();
+
+        if (!isFocused.current) {
+            handleResume();
+        }
     };
+    
+    function handleBlur(event) {
+        isFocused.current = false;
+        if (onBlur) {
+            onBlur(event);
+        }
+        handleResume();
+    }
+
+    function handleFocus(event) {
+        isFocused.current = true;
+        if (onFocus) {
+          onFocus(event);
+        }
+        handlePause();
+    }
 
     const handleClickAway = (event) => {
         if (onClose) {
@@ -103,7 +125,14 @@ const Snackbar = React.forwardRef((props, ref) => {
 
     return (
         <ClickAwayListener onClickAway={handleClickAway} {...ClickAwayListenerProps}>
-            <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} ref={ref} {...other}>
+            <div
+                onBlur={handleBlur}
+                onFocus={handleFocus}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+                ref={ref}
+                {...other}
+            >
                 {children}
             </div>
         </ClickAwayListener>


### PR DESCRIPTION
Problem: So, basically if we talking about accessibility - when user have focus on the snackbar we shouldn't hide snackbar after some autoHideDuration time. Notistack doesn't supports onFocus and onBlur events.

Steps to reproduce problem:
1) use 'Tab' key or screen reader to focus on snackbar (close icon, actions buttons, whole snackbar);
2) see that snackbar hides after `autoHideDuration` time passes.

How to test:
1) use 'Tab' key to focus on snackbar and be sure that snackbar doesn't close,
2) use 'Tab' key or mouse click on other space to blur and be sure that snackbar hide after `autoHideDuration` provided time.
3) use 'Tab' key to focus on snackbar and make onMouseLeave event and be sure that timer didn't resumed and snackbar didn't hide.