### PR TITLE
Update engine versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "releaseDraft": false
     },
     "engines": {
-        "node": "14",
-        "npm": "6"
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
     }
 }


### PR DESCRIPTION
Fix errors when installing with newer versions of node & npm

Before this change the following error happened:

```
$ npm i                                                                                                                                                       
npm WARN old lockfile 
npm WARN old lockfile The package-lock.json file was created with an old version of npm,
npm WARN old lockfile so supplemental metadata must be fetched from the registry.
npm WARN old lockfile 
npm WARN old lockfile This is a one-time fix-up, please be patient...
npm WARN old lockfile 
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: notistack@3.0.0-alpha.3
npm ERR! notsup Not compatible with your version of node/npm: notistack@3.0.0-alpha.3
npm ERR! notsup Required: {"node":"14","npm":"6"}
npm ERR! notsup Actual:   {"npm":"7.24.2","node":"v14.18.2"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/antti/.npm/_logs/2022-06-13T06_32_39_026Z-debug.log
```