### PR TITLE
export MaterialDesignContent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { default as SnackbarProvider, enqueueSnackbar, closeSnackbar } from './S
 export { default as SnackbarContent } from './SnackbarContent';
 export { default as useSnackbar } from './useSnackbar';
 export { default as Transition } from './transitions/Transition';
+export { default as MaterialDesignContent } from './ui/MaterialDesignContent';


### PR DESCRIPTION
Export the default MaterialDesignContent, so that minor modifications to it can be made.
Just by allowing this component to be wrapped would be really helpful if you wanted to make extremely minor adjustments to the default contents.
Related is issue #461 
For example, if you just want to change the background color for the 'info' variant, you either have to always pass in the styles everytime you call enqueueSnackbar, or reimplement the entire component and override it in SnackbarProvider.
There is no way currently to make extremely minor modifications to the default components.

Exporting it would allow some minor styling to be generalised, even if not perfect, as when creating a Snackbar override, the default one can simply be wrapped instead of entirely re-created.