### PR TITLE
Allow overriding styles of Material Snackbar

### DIFF
--- a/examples/custom-snackbar-example-2/src/ReportComplete.tsx
+++ b/examples/custom-snackbar-example-2/src/ReportComplete.tsx
@@ -20,7 +20,6 @@ const useStyles = makeStyles(() => ({
     }
   },
   card: {
-    backgroundColor: "#fddc6c",
     width: "100%"
   },
   typography: {
@@ -76,7 +75,7 @@ const ReportComplete = forwardRef<HTMLDivElement, ReportCompleteProps>(
 
     return (
       <SnackbarContent ref={ref} className={classes.root}>
-        <Card className={classes.card}>
+        <Card className={classes.card} style={{ backgroundColor: "#fddc6c" }}>
           <CardActions classes={{ root: classes.actionRoot }}>
             <Typography variant="body2" className={classes.typography}>
               {props.message}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { default as SnackbarProvider, enqueueSnackbar, closeSnackbar } from './S
 export { default as SnackbarContent } from './SnackbarContent';
 export { default as useSnackbar } from './useSnackbar';
 export { default as Transition } from './transitions/Transition';
+export { default as MaterialDesignContent } from './ui/MaterialDesignContent';

--- a/src/types.ts
+++ b/src/types.ts
@@ -424,3 +424,7 @@ export declare const SnackbarContent: (
 ) => React.ReactElement<any, any>;
 
 export declare const Transition: React.JSXElementConstructor<TransitionComponentProps>;
+
+export declare const MaterialDesignContent: (
+    props: CustomContentProps & React.RefAttributes<HTMLDivElement>
+) => React.ReactElement<any, any>;

--- a/src/ui/MaterialDesignContent/MaterialDesignContent.tsx
+++ b/src/ui/MaterialDesignContent/MaterialDesignContent.tsx
@@ -75,6 +75,7 @@ const MaterialDesignContent = forwardRef<HTMLDivElement, CustomContentProps>((pr
             style={style}
             className={clsx(
                 ComponentClasses.MuiContent,
+                ComponentClasses.MuiContentVariant(variant),
                 classes.root,
                 { [classes.lessPadding]: !hideIconVariant && icon },
                 classes[variant],

--- a/src/ui/MaterialDesignContent/MaterialDesignContent.tsx
+++ b/src/ui/MaterialDesignContent/MaterialDesignContent.tsx
@@ -50,7 +50,16 @@ const classes = makeStyles({
 });
 
 const MaterialDesignContent = forwardRef<HTMLDivElement, CustomContentProps>((props, forwardedRef) => {
-    const { id, message, action: componentOrFunctionAction, iconVariant, variant, hideIconVariant, style } = props;
+    const {
+        id,
+        message,
+        action: componentOrFunctionAction,
+        iconVariant,
+        variant,
+        hideIconVariant,
+        style,
+        className,
+    } = props;
 
     const icon = iconVariant[variant];
 
@@ -68,7 +77,8 @@ const MaterialDesignContent = forwardRef<HTMLDivElement, CustomContentProps>((pr
                 ComponentClasses.MuiContent,
                 classes.root,
                 { [classes.lessPadding]: !hideIconVariant && icon },
-                classes[variant]
+                classes[variant],
+                className
             )}
         >
             <div id="notistack-snackbar" className={classes.message}>

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -17,4 +17,5 @@ export const ComponentClasses = {
     Snackbar: 'notistack-Snackbar',
     CollapseWrapper: 'notistack-CollapseWrapper',
     MuiContent: 'notistack-MuiContent',
+    MuiContentVariant: (variant: string) => `notistack-MuiContent-${variant}`,
 };

--- a/typedoc.json
+++ b/typedoc.json
@@ -8169,6 +8169,98 @@
 			}
 		},
 		{
+			"id": 333,
+			"name": "MaterialDesignContent",
+			"kind": 32,
+			"kindString": "Variable",
+			"flags": {
+				"isExported": true,
+				"isConst": true
+			},
+			"sources": [
+				{
+					"fileName": "src/types.ts",
+					"line": 428,
+					"character": 42
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 334,
+					"name": "__type",
+					"kind": 65536,
+					"kindString": "Type literal",
+					"flags": {
+						"isExported": true
+					},
+					"signatures": [
+						{
+							"id": 335,
+							"name": "__call",
+							"kind": 4096,
+							"kindString": "Call signature",
+							"flags": {
+								"isExported": true
+							},
+							"parameters": [
+								{
+									"id": 336,
+									"name": "props",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {
+										"isExported": true
+									},
+									"type": {
+										"type": "intersection",
+										"types": [
+											{
+												"type": "reference",
+												"id": 321,
+												"name": "CustomContentProps"
+											},
+											{
+												"type": "reference",
+												"typeArguments": [
+													{
+														"type": "reference",
+														"name": "HTMLDivElement"
+													}
+												],
+												"name": "RefAttributes"
+											}
+										]
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "any"
+									},
+									{
+										"type": "intrinsic",
+										"name": "any"
+									}
+								],
+								"name": "ReactElement"
+							}
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/types.ts",
+							"line": 428,
+							"character": 43
+						}
+					]
+				}
+			}
+		},
+		{
 			"id": 328,
 			"name": "SnackbarContent",
 			"kind": 32,
@@ -8473,6 +8565,7 @@
 			"title": "Variables",
 			"kind": 32,
 			"children": [
+				333,
 				328,
 				332,
 				327,


### PR DESCRIPTION
Fixes #461 #539.

Example: Override error or succes variant colors:

```tsx
import { MaterialDesignContent } from 'notistack'

const StyledMaterialDesignContent = styled(MaterialDesignContent)(() => ({
  '&.notistack-MuiContent-success': {
    backgroundColor: '#2D7738',
  },
  '&.notistack-MuiContent-error': {
    backgroundColor: '#970C0C',
  },
}));

<SnackbarProvider
  Components={{
    success: StyledMaterialDesignContent,
    error: StyledMaterialDesignContent,
  }}
>
```