### PR TITLE
Fix regression of aria-describedby on MaterialDesignContent

### DIFF
--- a/src/ui/MaterialDesignContent/MaterialDesignContent.tsx
+++ b/src/ui/MaterialDesignContent/MaterialDesignContent.tsx
@@ -72,6 +72,7 @@ const MaterialDesignContent = forwardRef<HTMLDivElement, CustomContentProps>((pr
         <SnackbarContent
             ref={forwardedRef}
             role="alert"
+            aria-describedby="notistack-snackbar"
             style={style}
             className={clsx(
                 ComponentClasses.MuiContent,


### PR DESCRIPTION

Thanks for the work on v3! I was looking into upgrading to it but currently this is blocking me from updating to v3.

I want to continue to use `MaterialDesignContent`, but my tests depend on the fact that `SnackbarContent` has `role="alert"` and `aria-describedby="notistack-snackbar"`. This also makes the snackbar more accessible.

There appears to be no other way to set `aria-describedby` on `SnackbarContent`.

This restores the behaviour prior to v3.