### PR TITLE
fix: Omit content from SharedProps to resolve type incompatibility with @types/react v18.2.x+

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -171,7 +171,7 @@ export interface SnackbarProps extends StandardProps<React.HTMLAttributes<HTMLDi
 /**
  * @category Shared
  */
-export interface SharedProps extends Omit<SnackbarProps, 'classes'>, Partial<TransitionHandlerProps> {
+export interface SharedProps extends Omit<SnackbarProps, 'classes' | 'content'>, Partial<TransitionHandlerProps> {
     /**
      * Used to easily display different variant of snackbars. When passed to `SnackbarProvider`
      * all snackbars inherit the `variant`, unless you override it in `enqueueSnackbar` options.


### PR DESCRIPTION
Due to the changes in [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64972), the type of content in HTMLAttributes has been modified. This has caused the following error to occur in versions of @types/react v18.2.x and later. I've made adjustments by omitting content.

```
../node_modules/notistack/dist/index.d.ts(174,18): error TS2430: Interface 'SharedProps' incorrectly extends interface 'Omit<SnackbarProps, "classes">'.
  Types of property 'content' are incompatible.
    Type 'SnackbarContentCallback' is not assignable to type 'string | undefined'.
      Type 'null' is not assignable to type 'string | undefined'.
```