### PR TITLE
Use a different aria-describedBy target for each notification

### DIFF
--- a/src/ui/MaterialDesignContent/MaterialDesignContent.tsx
+++ b/src/ui/MaterialDesignContent/MaterialDesignContent.tsx
@@ -49,7 +49,7 @@ const classes = makeStyles({
     },
 });
 
-const ariaDescribedby = 'notistack-snackbar';
+const ariaDescribedbyPrefix = 'notistack-snackbar';
 
 const MaterialDesignContent = forwardRef<HTMLDivElement, CustomContentProps>((props, forwardedRef) => {
     const {
@@ -69,6 +69,8 @@ const MaterialDesignContent = forwardRef<HTMLDivElement, CustomContentProps>((pr
     if (typeof action === 'function') {
         action = action(id);
     }
+
+    const ariaDescribedby = `${ariaDescribedbyPrefix}-${id}`;
 
     return (
         <SnackbarContent


### PR DESCRIPTION
I noticed that all notifications had the same aria-describedBy reference. This was a problem when several notifications were displayed in the same time. This patch fixes this issue.
I manually tested with a local project.