### PR TITLE
Allow for reason override in closeSnackbar

### DIFF
--- a/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/src/SnackbarProvider/SnackbarProvider.tsx
@@ -255,14 +255,14 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
     /**
      * Close snackbar with the given key
      */
-    closeSnackbar: ProviderContext['closeSnackbar'] = (key) => {
+    closeSnackbar: ProviderContext['closeSnackbar'] = (key, reason = 'instructed') => {
         // call individual snackbar onClose callback passed through options parameter
         const toBeClosed = this.state.snacks.find((item) => item.id === key);
         if (isDefined(key) && toBeClosed && toBeClosed.onClose) {
-            toBeClosed.onClose(null, 'instructed', key);
+            toBeClosed.onClose(null, reason, key);
         }
 
-        this.handleCloseSnack(null, 'instructed', key);
+        this.handleCloseSnack(null, reason, key);
     };
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,11 +279,11 @@ export interface SharedProps<V extends VariantType = VariantType> extends Partia
      * @param {object} event The event source of the callback
      * @param {string} reason Can be:`"timeout"` (`autoHideDuration` expired) or: `"maxsnack"`
      * (snackbar was closed because `maxSnack` has reached) or: `"instructed"` (snackbar was
-     * closed programmatically)
+     * closed programmatically) or: any string if closeSnackbar had reason parameter
      * @param {string|number|undefined} key key of a Snackbar. key will be `undefined` if closeSnackbar
      * is called with no key (user requested all the snackbars to be closed)
      */
-    onClose?: (event: React.SyntheticEvent<any> | null, reason: CloseReason, key?: SnackbarKey) => void;
+    onClose?: (event: React.SyntheticEvent<any> | null, reason: CloseReason | string, key?: SnackbarKey) => void;
 }
 
 /**
@@ -405,7 +405,7 @@ interface EnqueueSnackbar {
 
 export interface ProviderContext {
     enqueueSnackbar: EnqueueSnackbar;
-    closeSnackbar: (key?: SnackbarKey) => void;
+    closeSnackbar: (key?: SnackbarKey, reason?: string) => void;
 }
 
 export declare class SnackbarProvider extends React.Component<SnackbarProviderProps> {


### PR DESCRIPTION
Resolving issue found in: https://github.com/iamhosseindhv/notistack/issues/591

This PR allows you to override closeSnackbar reason, so you can act in `onClose` depending if user closed the snackbar himself or if it was for any other reason - like changing views and hiding snackbar.
This is useful if you want to be sure that user saw a snackbar, if user closed it himself you can save it to localStorage / DB.
The reason why you would want to close the snackbar while changing views is quite simple - context often matters and displaying same snackbar in different context may have different meaning.

Currently it is impossible to tell if a user intentionally closed a notification by clicking on the "close" button or if "closeSnackbar" was invoked from somewhere in the application for whatever reason. Both will deliver reason "instructed".

This is my first contribution ever, so unsure If I'm doing everything correctly.