### PR TITLE
Node.js-compatible ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,21 @@
     "version": "3.0.2",
     "description": "Highly customizable notification snackbars (toasts) that can be stacked on top of each other",
     "main": "./index.js",
-    "module": "./notistack.esm.js",
+    "module": "./notistack.esm.mjs",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./notistack.esm.d.mts",
+                "default": "./notistack.esm.mjs"
+            },
+            "require": {
+                "types": "./index.d.ts",
+                "default": "./index.js"
+            }
+        },
+        "./package.json": "./package.json"
+    },
     "license": "MIT",
     "author": {
         "name": "Hossein Dehnokhalaji",

--- a/tsdx.config.js
+++ b/tsdx.config.js
@@ -1,3 +1,4 @@
+const path = require('node:path');
 const copy = require('rollup-plugin-copy');
 const bundleSize = require('rollup-plugin-bundle-size');
 
@@ -6,11 +7,18 @@ const DIST_FOLDER = 'dist';
 module.exports = {
     rollup(config) {
         config.plugins.push(bundleSize());
+
+        let dts = 'index.d.ts';
+        // Write ESM as .mjs to match Node.js expectations.
+        if (config.output && config.output.format === 'esm') {
+            config.output.file = config.output.file.replace(/\.js$/, '.mjs');
+            dts = path.basename(config.output.file, '.mjs') + '.d.mts';
+        }
         config.plugins.push(
             copy({
                 targets: [
-                    // copy decleration file over
-                    { src: 'src/types.ts', dest: DIST_FOLDER, rename: 'index.d.ts' },
+                    // copy declaration file over
+                    { src: 'src/types.ts', dest: DIST_FOLDER, rename: dts },
                 ],
             })
         );


### PR DESCRIPTION
notistack ships both CJS (CommonJS) and ESM (ECMAScript Modules) versions by setting both the `main` and `module` fields of its package.json. The `module` field is a convention of bundlers such as Rollup (see https://stackoverflow.com/q/42708484/25507), but it isn't used by Node.js, and it's not used by TypeScript when TypeScript is configured to use Node.js-compatible resolution methods such as `"moduleResolution": "nodenext"`.

This caused problems for our project when we switched from CommonJS to ESM; Jest (which, from what I can tell, uses Node-style resolution) was no longer able to properly resolve notistack members for our automated tests.

(I'm not sure if this counts as a breaking change; I don't know why anyone would be affected, but module handling is complex enough that it may be better to err on the side of caution.)